### PR TITLE
Add shared article API and sync public views

### DIFF
--- a/api/articles-data.json
+++ b/api/articles-data.json
@@ -1,0 +1,22 @@
+{
+  "articles": [
+    {
+      "title": "スクロールスナップで魅せるiPad特集",
+      "body": "iPadOSのオーバースクロールに合わせた柔らかなカードUI。モバイルファーストの編集フローを紹介。",
+      "tags": ["iPad", "UI", "ScrollSnap"],
+      "image": "https://images.unsplash.com/photo-1526170375885-4d8ecf77b99f?auto=format&fit=crop&w=900&q=80"
+    },
+    {
+      "title": "LINE配信テンプレート付き記事運用",
+      "body": "配信用のOGPとLINEシェアURLをワンクリック生成。チャット経由での下書きアップロードにも対応。",
+      "tags": ["LINE", "OGP", "Automation"],
+      "image": "https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=900&q=80"
+    },
+    {
+      "title": "ChatGPT→ブログ 直貼りワークフロー",
+      "body": "ChatGPTで生成した文章をそのままペースト。カバー画像とタグを加えて即公開。",
+      "tags": ["ChatGPT", "Workflow", "Creator"],
+      "image": "https://images.unsplash.com/photo-1460925895917-afdab827c52f?auto=format&fit=crop&w=900&q=80"
+    }
+  ]
+}

--- a/api/articles.js
+++ b/api/articles.js
@@ -1,0 +1,85 @@
+import fs from "fs";
+import path from "path";
+
+const DATA_PATH = path.join(process.cwd(), "api", "articles-data.json");
+const seedArticles = [
+  {
+    title: "スクロールスナップで魅せるiPad特集",
+    body: "iPadOSのオーバースクロールに合わせた柔らかなカードUI。モバイルファーストの編集フローを紹介。",
+    tags: ["iPad", "UI", "ScrollSnap"],
+    image: "https://images.unsplash.com/photo-1526170375885-4d8ecf77b99f?auto=format&fit=crop&w=900&q=80",
+  },
+  {
+    title: "LINE配信テンプレート付き記事運用",
+    body: "配信用のOGPとLINEシェアURLをワンクリック生成。チャット経由での下書きアップロードにも対応。",
+    tags: ["LINE", "OGP", "Automation"],
+    image: "https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=900&q=80",
+  },
+  {
+    title: "ChatGPT→ブログ 直貼りワークフロー",
+    body: "ChatGPTで生成した文章をそのままペースト。カバー画像とタグを加えて即公開。",
+    tags: ["ChatGPT", "Workflow", "Creator"],
+    image: "https://images.unsplash.com/photo-1460925895917-afdab827c52f?auto=format&fit=crop&w=900&q=80",
+  },
+];
+
+function readSeedPayload() {
+  try {
+    return JSON.parse(fs.readFileSync(DATA_PATH, "utf8"));
+  } catch (err) {
+    return { articles: seedArticles };
+  }
+}
+
+const defaultPayload = readSeedPayload();
+
+function readArticles() {
+  try {
+    const raw = fs.readFileSync(DATA_PATH, "utf8");
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed;
+    if (Array.isArray(parsed.articles)) return parsed.articles;
+  } catch (err) {
+    // fall through to defaults
+  }
+  return defaultPayload.articles || [];
+}
+
+async function readJSON(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  const text = Buffer.concat(chunks).toString("utf8") || "{}";
+  return JSON.parse(text);
+}
+
+function persistArticles(articles) {
+  fs.writeFileSync(
+    DATA_PATH,
+    JSON.stringify({ articles }, null, 2),
+    "utf8"
+  );
+}
+
+export default async function handler(req, res) {
+  if (req.method === "GET") {
+    const articles = readArticles();
+    return res.status(200).json({ articles });
+  }
+
+  if (req.method === "POST") {
+    try {
+      const payload = await readJSON(req);
+      const nextArticles = Array.isArray(payload.articles) ? payload.articles : [];
+      if (!nextArticles.length) {
+        return res.status(400).json({ error: "articles array required" });
+      }
+      persistArticles(nextArticles);
+      return res.status(200).json({ ok: true, count: nextArticles.length });
+    } catch (err) {
+      return res.status(400).json({ error: "invalid payload" });
+    }
+  }
+
+  res.setHeader("Allow", ["GET", "POST"]);
+  return res.status(405).end();
+}

--- a/public/blog-article.html
+++ b/public/blog-article.html
@@ -158,38 +158,51 @@
 <script>
   const officialLineAccountId = "@projecte_official";
   const officialLinePage = "https://page.line.me/projecte_official";
+  const cacheKey = "emperor_articles_cache";
   const baseArticles = [
     {
-      title: "iPadスクロール特集 — 公式LINEで読む",
-      body: "黒背景とオーバースクロールを活かしたカードレイアウト。公式LINEアカウントへの配信リンクを同梱。",
-      tags: ["iPad", "Scroll", "LINE公式"],
-      image: "https://images.unsplash.com/photo-1472289065668-ce650ac443d2?auto=format&fit=crop&w=1200&q=80",
+      title: "スクロールスナップで魅せるiPad特集",
+      body: "iPadOSのオーバースクロールに合わせた柔らかなカードUI。モバイルファーストの編集フローを紹介。",
+      tags: ["iPad", "UI", "ScrollSnap"],
+      image: "https://images.unsplash.com/photo-1526170375885-4d8ecf77b99f?auto=format&fit=crop&w=900&q=80",
     },
     {
-      title: "ChatGPTから即公開",
-      body: "チャットで生成した原稿をそのまま貼り付け。タグとカバーを足すだけで読者向けカードを生成します。",
-      tags: ["ChatGPT", "Workflow"],
-      image: "https://images.unsplash.com/photo-1507138451611-3001135909a5?auto=format&fit=crop&w=1200&q=80",
+      title: "LINE配信テンプレート付き記事運用",
+      body: "配信用のOGPとLINEシェアURLをワンクリック生成。チャット経由での下書きアップロードにも対応。",
+      tags: ["LINE", "OGP", "Automation"],
+      image: "https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=900&q=80",
     },
     {
-      title: "LINEシェアリンクをワンクリック",
-      body: "公式LINEアカウントと連動した共有ボタンを自動生成。外部ブラウザでも快適に閲覧できるOGP調整済み。",
-      tags: ["LINE", "Share", "OGP"],
-      image: "https://images.unsplash.com/photo-1508766206392-8bd5cf550d1b?auto=format&fit=crop&w=1200&q=80",
+      title: "ChatGPT→ブログ 直貼りワークフロー",
+      body: "ChatGPTで生成した文章をそのままペースト。カバー画像とタグを加えて即公開。",
+      tags: ["ChatGPT", "Workflow", "Creator"],
+      image: "https://images.unsplash.com/photo-1460925895917-afdab827c52f?auto=format&fit=crop&w=900&q=80",
     },
   ];
 
-  function loadArticles() {
-    const saved = localStorage.getItem("emperor_articles");
-    return saved ? JSON.parse(saved) : baseArticles;
+  async function fetchArticles() {
+    try {
+      const res = await fetch("/api/articles");
+      if (!res.ok) throw new Error("failed to fetch articles");
+      const payload = await res.json();
+      const articles = Array.isArray(payload.articles) ? payload.articles : [];
+      if (!articles.length) throw new Error("no articles available");
+      localStorage.setItem(cacheKey, JSON.stringify(articles));
+      return articles;
+    } catch (err) {
+      const cached = localStorage.getItem(cacheKey);
+      if (cached) return JSON.parse(cached);
+      return baseArticles;
+    }
   }
 
-  function findArticle() {
+  async function findArticle() {
     const params = new URLSearchParams(location.search);
     const idx = parseInt(params.get("id"), 10);
-    const list = loadArticles();
-    const article = Number.isFinite(idx) && list[idx] ? list[idx] : list[0];
-    return { article, list, idx: Number.isFinite(idx) && list[idx] ? idx : 0 };
+    const list = await fetchArticles();
+    const isValidIdx = Number.isFinite(idx) && list[idx];
+    const article = isValidIdx ? list[idx] : list[0];
+    return { article, list, idx: isValidIdx ? idx : 0 };
   }
 
   function paragraphize(text) {
@@ -243,8 +256,8 @@
     });
   }
 
-  document.addEventListener("DOMContentLoaded", () => {
-    const { article, idx } = findArticle();
+  document.addEventListener("DOMContentLoaded", async () => {
+    const { article, idx } = await findArticle();
     render(article, idx);
   });
 </script>

--- a/public/blog-public.html
+++ b/public/blog-public.html
@@ -151,25 +151,26 @@
   const ticker = document.getElementById("ticker");
   const tickerClone = document.getElementById("tickerClone");
   const metaInfo = document.getElementById("metaInfo");
+  const cacheKey = "emperor_articles_cache";
 
   const baseArticles = [
     {
-      title: "iPadスクロール特集 — 公式LINEで読む",
-      body: "黒背景とオーバースクロールを活かしたカードレイアウト。公式LINEアカウントへの配信リンクを同梱。",
-      tags: ["iPad", "Scroll", "LINE公式"],
-      image: "https://images.unsplash.com/photo-1472289065668-ce650ac443d2?auto=format&fit=crop&w=1200&q=80",
+      title: "スクロールスナップで魅せるiPad特集",
+      body: "iPadOSのオーバースクロールに合わせた柔らかなカードUI。モバイルファーストの編集フローを紹介。",
+      tags: ["iPad", "UI", "ScrollSnap"],
+      image: "https://images.unsplash.com/photo-1526170375885-4d8ecf77b99f?auto=format&fit=crop&w=900&q=80",
     },
     {
-      title: "ChatGPTから即公開",
-      body: "チャットで生成した原稿をそのまま貼り付け。タグとカバーを足すだけで読者向けカードを生成します。",
-      tags: ["ChatGPT", "Workflow"],
-      image: "https://images.unsplash.com/photo-1507138451611-3001135909a5?auto=format&fit=crop&w=1200&q=80",
+      title: "LINE配信テンプレート付き記事運用",
+      body: "配信用のOGPとLINEシェアURLをワンクリック生成。チャット経由での下書きアップロードにも対応。",
+      tags: ["LINE", "OGP", "Automation"],
+      image: "https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=900&q=80",
     },
     {
-      title: "LINEシェアリンクをワンクリック",
-      body: "公式LINEアカウントと連動した共有ボタンを自動生成。外部ブラウザでも快適に閲覧できるOGP調整済み。",
-      tags: ["LINE", "Share", "OGP"],
-      image: "https://images.unsplash.com/photo-1508766206392-8bd5cf550d1b?auto=format&fit=crop&w=1200&q=80",
+      title: "ChatGPT→ブログ 直貼りワークフロー",
+      body: "ChatGPTで生成した文章をそのままペースト。カバー画像とタグを加えて即公開。",
+      tags: ["ChatGPT", "Workflow", "Creator"],
+      image: "https://images.unsplash.com/photo-1460925895917-afdab827c52f?auto=format&fit=crop&w=900&q=80",
     }
   ];
 
@@ -177,9 +178,20 @@
     return `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(url)}&accountId=@projecte_official`;
   }
 
-  function loadArticles() {
-    const saved = localStorage.getItem("emperor_articles");
-    return saved ? JSON.parse(saved) : baseArticles;
+  async function fetchArticles() {
+    try {
+      const res = await fetch("/api/articles");
+      if (!res.ok) throw new Error("failed to fetch articles");
+      const payload = await res.json();
+      const articles = Array.isArray(payload.articles) ? payload.articles : [];
+      if (!articles.length) throw new Error("no articles found");
+      localStorage.setItem(cacheKey, JSON.stringify(articles));
+      return articles;
+    } catch (err) {
+      const cached = localStorage.getItem(cacheKey);
+      if (cached) return JSON.parse(cached);
+      return baseArticles;
+    }
   }
 
   function renderTicker(tags) {
@@ -220,9 +232,9 @@
     });
   }
 
-  document.addEventListener("DOMContentLoaded", () => {
+  document.addEventListener("DOMContentLoaded", async () => {
     document.getElementById("openLine").href = officialLinePage;
-    const articles = loadArticles();
+    const articles = await fetchArticles();
     renderFeed(articles);
     renderTicker(articles.flatMap(a => a.tags || []));
     renderMeta(articles.length);

--- a/public/blog.html
+++ b/public/blog.html
@@ -298,6 +298,8 @@
   const tagMarqueeClone = document.getElementById("tagMarqueeClone");
   const officialLineAccountId = "@projecte_official";
   const officialLinePage = "https://page.line.me/projecte_official";
+  const cacheKey = "emperor_articles_cache";
+  let currentArticles = [];
 
   const baseArticles = [
     {
@@ -320,15 +322,30 @@
     }
   ];
 
-  function loadArticles() {
-    const saved = localStorage.getItem("emperor_articles");
-    const data = saved ? JSON.parse(saved) : baseArticles;
-    renderFeatures(data);
-    renderFeed(data);
+  async function fetchArticles() {
+    try {
+      const res = await fetch("/api/articles");
+      if (!res.ok) throw new Error("failed to fetch articles");
+      const payload = await res.json();
+      const articles = Array.isArray(payload.articles) ? payload.articles : [];
+      if (!articles.length) throw new Error("no articles in payload");
+      localStorage.setItem(cacheKey, JSON.stringify(articles));
+      return articles;
+    } catch (e) {
+      const cached = localStorage.getItem(cacheKey);
+      if (cached) return JSON.parse(cached);
+      return baseArticles;
+    }
   }
 
-  function persist(articles) {
-    localStorage.setItem("emperor_articles", JSON.stringify(articles));
+  async function saveArticles(articles) {
+    const res = await fetch("/api/articles", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ articles }),
+    });
+    if (!res.ok) throw new Error("failed to persist articles");
+    localStorage.setItem(cacheKey, JSON.stringify(articles));
   }
 
   function buildOfficialLineShare(url) {
@@ -421,15 +438,20 @@
       return;
     }
 
-    const saved = localStorage.getItem("emperor_articles");
-    const list = saved ? JSON.parse(saved) : [...baseArticles];
     const image = imgFile ? await readFileAsDataURL(imgFile) : "";
 
     const article = { title, body, tags, image };
-    const updated = [article, ...list];
-    persist(updated);
-    renderFeatures(updated);
-    renderFeed(updated);
+    const updated = [article, ...currentArticles];
+
+    try {
+      await saveArticles(updated);
+      currentArticles = updated;
+      renderFeatures(updated);
+      renderFeed(updated);
+    } catch (err) {
+      alert("保存に失敗しました。時間をおいて再度お試しください。");
+      return;
+    }
 
     document.getElementById("body").value = "";
     document.getElementById("title").value = "";
@@ -437,10 +459,15 @@
     document.getElementById("image").value = "";
   });
 
-  document.getElementById("seedDemo").addEventListener("click", () => {
-    persist(baseArticles);
-    renderFeatures(baseArticles);
-    renderFeed(baseArticles);
+  document.getElementById("seedDemo").addEventListener("click", async () => {
+    try {
+      await saveArticles(baseArticles);
+      currentArticles = baseArticles;
+      renderFeatures(baseArticles);
+      renderFeed(baseArticles);
+    } catch (err) {
+      alert("デモ記事の同期に失敗しました");
+    }
   });
 
   document.getElementById("copyLink").addEventListener("click", (e) => {
@@ -461,10 +488,12 @@
     });
   }, { threshold: 0.2 });
 
-  document.addEventListener("DOMContentLoaded", () => {
+  document.addEventListener("DOMContentLoaded", async () => {
     document.getElementById("lineOfficial").href = officialLinePage;
     document.getElementById("lineOfficial").textContent = `${officialLineAccountId} を開く`;
-    loadArticles();
+    currentArticles = await fetchArticles();
+    renderFeatures(currentArticles);
+    renderFeed(currentArticles);
   });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add an API-backed shared article data source with persisted seed content
- update blog admin/upload page to fetch and save articles via the API while refreshing local cache
- refresh public and article views from the shared API data and rerender feature/feed content

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941e875c5b8832185ace9cd87d1c745)