### PR TITLE
Add dedicated article editor behind admin login

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -162,8 +162,8 @@
         </div>
         <div class="stack">
           <div class="actions">
-            <a class="pill" href="/blog.html" id="openManager">記事管理を開く</a>
-            <a class="pill" href="/blog-public.html">公開ビューを見る</a>
+            <a class="pill" href="/blog-edit.html" id="openManager">記事編集ページ</a>
+            <a class="pill" href="/blog.html">公開ビューを開く</a>
           </div>
           <p class="hint">管理リンクは認証済みセッションでのみ利用できます。</p>
         </div>

--- a/public/blog-article.html
+++ b/public/blog-article.html
@@ -100,7 +100,7 @@
   async function findArticle() {
     const params = new URLSearchParams(location.search);
     const idx = parseInt(params.get("id"), 10);
-    const list = await fetchArticles();
+    const list = loadArticles();
     const isValidIdx = Number.isFinite(idx) && list[idx];
     const article = isValidIdx ? list[idx] : list[0];
     return { article, list, idx: isValidIdx ? idx : 0 };

--- a/public/blog-edit.html
+++ b/public/blog-edit.html
@@ -1,0 +1,226 @@
+<!doctype html>
+<html lang="ja">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>記事編集 | Emperor News</title>
+<link rel="stylesheet" href="/assets/blog-shared.css">
+<style>
+  body { background: radial-gradient(circle at 14% 12%, rgba(6,199,85,0.16), transparent 38%), var(--bg); }
+  main { padding: 22px 18px 48px; display: grid; gap: 18px; }
+  .stack { display: grid; gap: 12px; }
+  .panel {
+    background: rgba(10,12,20,0.9);
+    border: 1px solid var(--border);
+    border-radius: 18px;
+    padding: 16px;
+    box-shadow: var(--shadow);
+  }
+  .panel h2 { margin: 0 0 4px; font-size: 18px; }
+  .panel p { margin: 0 0 10px; color: var(--muted); }
+  label { display: block; font-size: 12px; color: var(--muted); margin-bottom: 6px; }
+  input, textarea {
+    width: 100%;
+    border-radius: 12px;
+    border: 1px solid var(--border);
+    background: #090b12;
+    color: #f8fafc;
+    padding: 12px;
+    font-size: 15px;
+  }
+  textarea { min-height: 160px; resize: vertical; }
+  .actions { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
+  button { border: none; border-radius: 12px; padding: 12px 14px; font-weight: 700; cursor: pointer; }
+  button.primary { background: #16a34a; color: #ecfdf3; box-shadow: 0 8px 20px rgba(22,163,74,0.35); }
+  button.secondary { background: transparent; border: 1px solid var(--border); color: var(--text); }
+  .list { display: grid; gap: 10px; }
+  .item {
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 12px;
+    background: linear-gradient(120deg, rgba(6,199,85,0.12), rgba(6,199,85,0.04));
+    display: grid;
+    gap: 6px;
+  }
+  .item h3 { margin: 0; font-size: 16px; }
+  .badge { padding: 6px 10px; border-radius: 10px; background: rgba(6,199,85,0.12); border: 1px solid rgba(6,199,85,0.35); color: #bbf7d0; font-size: 12px; width: fit-content; }
+  .muted { color: var(--muted); font-size: 13px; margin: 0; }
+  .tag-row { display: flex; gap: 6px; flex-wrap: wrap; }
+  .tag-row .tag { background: rgba(255,255,255,0.05); border: 1px solid var(--border); }
+  .empty { color: var(--muted); font-size: 14px; }
+</style>
+<body>
+  <script>
+    (function enforceAdminSession() {
+      const SESSION_KEY = "emperor_admin_token";
+      const authed = sessionStorage.getItem(SESSION_KEY) === "active";
+      if (!authed) {
+        const destination = encodeURIComponent(location.pathname + location.search + location.hash);
+        window.location.replace(`/admin.html?redirect=${destination}`);
+      }
+    })();
+  </script>
+
+  <header>
+    <div class="brand">
+      <div class="logo">E</div>
+      <div>
+        <h1>記事編集</h1>
+        <p>公開ビューとは別の管理用編集ページ</p>
+      </div>
+    </div>
+    <div class="actions">
+      <a class="pill" href="/blog.html">公開一覧へ戻る</a>
+      <a class="pill" href="/admin.html">認証ページ</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="panel stack">
+      <div class="actions" style="justify-content: space-between; align-items: flex-start; flex-wrap: wrap;">
+        <div class="stack">
+          <div class="badge" id="status">ログイン中</div>
+          <h2 style="margin:0">記事の新規追加・編集</h2>
+          <p style="margin:0">タイトル・本文・タグ・カバー画像URLを入力して保存します。</p>
+        </div>
+        <button class="secondary" id="newBtn">新規作成</button>
+      </div>
+
+      <form class="stack" id="editorForm">
+        <div>
+          <label for="title">タイトル</label>
+          <input id="title" name="title" required placeholder="記事タイトル">
+        </div>
+        <div>
+          <label for="body">本文 (複数段落は空行で区切ってください)</label>
+          <textarea id="body" name="body" required placeholder="本文を入力"></textarea>
+        </div>
+        <div>
+          <label for="tags">タグ (カンマ区切り)</label>
+          <input id="tags" name="tags" placeholder="iPhone, iPad, 公式LINE">
+        </div>
+        <div>
+          <label for="image">カバー画像URL</label>
+          <input id="image" name="image" type="url" placeholder="https://example.com/cover.jpg">
+        </div>
+        <div class="actions">
+          <button class="primary" type="submit" id="saveBtn">保存する</button>
+          <p class="muted" id="helper">新しい記事を作成します。</p>
+        </div>
+      </form>
+    </section>
+
+    <section class="panel">
+      <h2>保存済みの記事</h2>
+      <p class="muted">ローカル保存された記事を編集または削除できます。</p>
+      <div class="list" id="articleList"></div>
+    </section>
+  </main>
+
+<script src="/assets/blog-data.js"></script>
+<script>
+  const SESSION_KEY = "emperor_admin_token";
+  const form = document.getElementById("editorForm");
+  const articleList = document.getElementById("articleList");
+  const statusLabel = document.getElementById("status");
+  const helper = document.getElementById("helper");
+  const saveBtn = document.getElementById("saveBtn");
+  let editingIdx = null;
+
+  function parseTags(input) {
+    return input.split(/[,\n]/).map(t => t.trim()).filter(Boolean);
+  }
+
+  function formatTags(tags) {
+    return (tags || []).join(", ");
+  }
+
+  function setSessionBadge() {
+    const authed = sessionStorage.getItem(SESSION_KEY) === "active";
+    statusLabel.textContent = authed ? "ログイン中: admin" : "未ログイン";
+  }
+
+  function renderList() {
+    const articles = BlogData.loadArticles();
+    articleList.innerHTML = "";
+    if (!articles.length) {
+      articleList.innerHTML = '<p class="empty">まだ記事がありません。フォームから追加してください。</p>';
+      return;
+    }
+
+    articles.forEach((article, idx) => {
+      const item = document.createElement("div");
+      item.className = "item";
+      item.innerHTML = `
+        <div class="actions" style="justify-content: space-between; align-items: flex-start;">
+          <div class="stack" style="gap:4px;">
+            <h3>${article.title || "無題の記事"}</h3>
+            <p class="muted">${article.body?.slice(0, 80) || "本文がありません"}</p>
+            <div class="tag-row">${(article.tags || []).map(tag => `<span class="tag">#${tag}</span>`).join("") || '<span class="tag">#untagged</span>'}</div>
+          </div>
+          <div class="stack" style="gap:6px; align-items:flex-end;">
+            <button class="secondary" data-action="edit" data-idx="${idx}">編集</button>
+            <button class="secondary" data-action="delete" data-idx="${idx}">削除</button>
+          </div>
+        </div>
+      `;
+      articleList.appendChild(item);
+    });
+  }
+
+  function fillForm(article, idx) {
+    document.getElementById("title").value = article?.title || "";
+    document.getElementById("body").value = article?.body || "";
+    document.getElementById("tags").value = formatTags(article?.tags);
+    document.getElementById("image").value = article?.image || "";
+    editingIdx = Number.isInteger(idx) ? idx : null;
+    helper.textContent = editingIdx === null ? "新しい記事を作成します。" : `ID ${editingIdx} を編集中です。`;
+    saveBtn.textContent = editingIdx === null ? "保存する" : "更新する";
+  }
+
+  function handleSave(event) {
+    event.preventDefault();
+    const payload = {
+      title: document.getElementById("title").value.trim(),
+      body: document.getElementById("body").value.trim(),
+      tags: parseTags(document.getElementById("tags").value),
+      image: document.getElementById("image").value.trim(),
+    };
+
+    BlogData.upsertArticle(payload, editingIdx);
+    fillForm({}, null);
+    renderList();
+    alert("記事を保存しました");
+  }
+
+  function handleListClick(event) {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    const idx = parseInt(target.dataset.idx, 10);
+    if (!Number.isFinite(idx)) return;
+
+    if (target.dataset.action === "edit") {
+      const { article } = BlogData.findArticle(idx);
+      fillForm(article, idx);
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+
+    if (target.dataset.action === "delete") {
+      if (confirm("この記事を削除しますか？")) {
+        BlogData.deleteArticle(idx);
+        renderList();
+      }
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    setSessionBadge();
+    renderList();
+    fillForm({}, null);
+  });
+
+  form.addEventListener("submit", handleSave);
+  articleList.addEventListener("click", handleListClick);
+  document.getElementById("newBtn").addEventListener("click", () => fillForm({}, null));
+</script>
+</body>
+</html>

--- a/public/blog-public.html
+++ b/public/blog-public.html
@@ -67,7 +67,7 @@
     </div>
     <div class="actions">
       <a class="pill" href="/">トップ</a>
-      <a class="pill primary" href="/blog.html" data-requires-auth="true">編集・アップロード</a>
+      <a class="pill primary" href="/blog-edit.html" data-requires-auth="true">編集・アップロード</a>
     </div>
   </header>
 
@@ -78,7 +78,7 @@
       <p>管理画面やチャットから登録した記事をそのまま公開。黒基調のモバイル最適化カードで、公式LINEアカウントにもシェアできます。リンクだけで友だち追加と記事閲覧を両立。</p>
       <div class="cta-row">
         <a class="pill primary" id="openLine" rel="noreferrer">公式LINEで読む</a>
-        <a class="pill" href="/blog.html#upload" data-requires-auth="true">記事を投稿する</a>
+        <a class="pill" href="/blog-edit.html" data-requires-auth="true">記事を投稿する</a>
       </div>
       <div class="cta-row" id="metaInfo"></div>
     </section>
@@ -134,7 +134,7 @@
         if (authed) return;
 
         event.preventDefault();
-        const rawTarget = link.getAttribute("href") || "/blog.html";
+        const rawTarget = link.getAttribute("href") || "/blog-edit.html";
         const normalized = rawTarget.startsWith("/") ? rawTarget : `/${rawTarget}`;
         const redirect = encodeURIComponent(normalized);
         location.href = `/admin.html?redirect=${redirect}`;

--- a/public/blog.html
+++ b/public/blog.html
@@ -51,16 +51,6 @@
   @media (max-width: 680px) { .scroll-track { grid-auto-columns: 88%; } }
 </style>
 <body>
-  <script>
-    (function enforceAdminSession() {
-      const SESSION_KEY = "emperor_admin_token";
-      const authed = sessionStorage.getItem(SESSION_KEY) === "active";
-      if (!authed) {
-        const destination = encodeURIComponent(location.pathname + location.search + location.hash);
-        window.location.replace(`/admin.html?redirect=${destination}`);
-      }
-    })();
-  </script>
   <header>
     <div class="brand">
       <div class="logo">E</div>
@@ -72,6 +62,7 @@
     <div class="actions">
       <a class="pill" href="/">トップ</a>
       <a class="pill" id="openLine" target="_blank" rel="noreferrer">公式LINEで読む</a>
+      <a class="pill" href="/blog-edit.html" data-requires-auth="true">記事を編集</a>
     </div>
   </header>
 
@@ -105,6 +96,7 @@
   const tickerClone = document.getElementById("tickerClone");
   const featureTrack = document.getElementById("featureTrack");
   const metaInfo = document.getElementById("metaInfo");
+  const adminSessionKey = "emperor_admin_token";
 
   function renderTicker(tags) {
     const unique = Array.from(new Set(tags.length ? tags : ["iPhone", "iPad", "公式LINE", "黒ベース", "ChatGPTアップロード"]));
@@ -130,7 +122,7 @@
         ${item.image ? `<img class="hero-img" src="${item.image}" alt="${item.title}">` : ""}
         <h3>${item.title}</h3>
         <p>${item.body}</p>
-        <div class="meta">${(item.tags || []).map(t => `<span class="tag">#${t}</span>`).join("") || '<span class="tag">#untagged</span>'}</div>
+        <div class="meta">${(item.tags || []).map(t => `<span class=\"tag\">#${t}</span>`).join("") || '<span class="tag">#untagged</span>'}</div>
       `;
       featureTrack.appendChild(card);
     });
@@ -148,7 +140,7 @@
         ${item.image ? `<img class="hero-img" src="${item.image}" alt="${item.title}">` : ""}
         <h3>${item.title}</h3>
         <p>${item.body}</p>
-        <div class="meta">${(item.tags || []).map(t => `<span class="tag">#${t}</span>`).join("") || '<span class="tag">#untagged</span>'}</div>
+        <div class="meta">${(item.tags || []).map(t => `<span class=\"tag\">#${t}</span>`).join("") || '<span class="tag">#untagged</span>'}</div>
         <div class="share-row">
           <a class="share line" href="${shareUrl}" target="_blank" rel="noreferrer">公式LINEで共有</a>
           <a class="share" href="${articleUrl}" target="_blank">リンクを開く</a>
@@ -158,8 +150,25 @@
     });
   }
 
+  function enforceAdminLinks() {
+    const adminLinks = document.querySelectorAll('[data-requires-auth]');
+    adminLinks.forEach((link) => {
+      link.addEventListener("click", (event) => {
+        const authed = sessionStorage.getItem(adminSessionKey) === "active";
+        if (authed) return;
+
+        event.preventDefault();
+        const rawTarget = link.getAttribute("href") || "/blog-edit.html";
+        const normalized = rawTarget.startsWith("/") ? rawTarget : `/${rawTarget}`;
+        const redirect = encodeURIComponent(normalized);
+        location.href = `/admin.html?redirect=${redirect}`;
+      });
+    });
+  }
+
   document.addEventListener("DOMContentLoaded", () => {
     document.getElementById("openLine").href = officialLinePage;
+    enforceAdminLinks();
     const articles = BlogData.loadArticles();
     renderFeed(articles);
     renderFeatures(articles);


### PR DESCRIPTION
## Summary
- add a dedicated admin-only article editing page to manage stored blog posts
- keep the blog view public while redirecting edit links through the existing login flow
- refresh admin links and fix article loading to use the stored article list directly

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69425eb19d088321aaf8daefdd355999)