### PR TITLE
Improve automatic mobile layout for blog view

### DIFF
--- a/public/assets/blog-shared.css
+++ b/public/assets/blog-shared.css
@@ -130,3 +130,28 @@ footer {
 @media (min-width: 740px) {
   header { gap: 16px; }
 }
+
+body.is-mobile {
+  align-items: stretch;
+}
+
+body.is-mobile header,
+body.is-mobile main,
+body.is-mobile footer {
+  width: 100%;
+  max-width: none;
+}
+
+body.is-mobile header {
+  padding: 12px 16px;
+  gap: 10px;
+}
+
+body.is-mobile .actions {
+  width: 100%;
+  justify-content: flex-start;
+}
+
+body.is-mobile .pill {
+  width: auto;
+}

--- a/public/blog.html
+++ b/public/blog.html
@@ -98,6 +98,12 @@
   const featureTrack = document.getElementById("featureTrack");
   const metaInfo = document.getElementById("metaInfo");
   const adminSessionKey = "emperor_admin_token";
+  const mobileQuery = window.matchMedia("(max-width: 720px)");
+
+  function syncMobileClass(event) {
+    const isMobile = event ? event.matches : mobileQuery.matches;
+    document.body.classList.toggle("is-mobile", isMobile);
+  }
 
   function renderTicker(tags) {
     const unique = Array.from(new Set(tags.length ? tags : ["iPhone", "iPad", "公式LINE", "黒ベース", "ChatGPTアップロード"]));
@@ -168,6 +174,12 @@
   }
 
   document.addEventListener("DOMContentLoaded", () => {
+    syncMobileClass();
+    if (typeof mobileQuery.addEventListener === "function") {
+      mobileQuery.addEventListener("change", syncMobileClass);
+    } else if (typeof mobileQuery.addListener === "function") {
+      mobileQuery.addListener(syncMobileClass);
+    }
     document.getElementById("openLine").href = officialLinePage;
     enforceAdminLinks();
     const articles = BlogData.loadArticles();


### PR DESCRIPTION
## Summary
- add matchMedia-based mobile detection to toggle mobile layout styling on the blog view
- adjust shared blog styles to provide full-width mobile layout with stacked actions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69426876e9608321909eb91118fb389c)