### PR TITLE
Revamp responsive layouts across public pages

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -3,173 +3,64 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Emperor News Admin</title>
-<style>
-  :root {
-    --bg: #05070c;
-    --panel: #0c0f1a;
-    --accent: #38bdf8;
-    --accent-strong: #0ea5e9;
-    --text: #e5e7eb;
-    --muted: #9ca3af;
-    --border: #1f2937;
-    --success: #22c55e;
-    --danger: #f87171;
-    --radius: 14px;
-    --shadow: 0 20px 60px rgba(8, 15, 35, 0.45);
-  }
-  * { box-sizing: border-box; }
-  body {
-    margin: 0;
-    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
-    background: radial-gradient(circle at top, rgba(56,189,248,0.14), transparent 38%),
-                radial-gradient(circle at 20% 20%, rgba(34,197,94,0.08), transparent 30%),
-                var(--bg);
-    color: var(--text);
-    min-height: 100vh;
-    display: grid;
-    place-items: center;
-    padding: 24px;
-  }
-  .shell {
-    width: min(980px, 100%);
-    background: linear-gradient(145deg, rgba(12,15,26,0.96), rgba(8,10,18,0.92));
-    border: 1px solid rgba(148, 163, 184, 0.14);
-    border-radius: 22px;
-    box-shadow: var(--shadow);
-    overflow: hidden;
-  }
-  header {
-    padding: 18px 22px;
-    border-bottom: 1px solid rgba(148, 163, 184, 0.16);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 12px;
-    background: radial-gradient(circle at 14% 10%, rgba(56,189,248,0.15), transparent 40%);
-  }
-  .brand { display: flex; align-items: center; gap: 12px; }
-  .logo {
-    width: 44px;
-    height: 44px;
-    border-radius: 12px;
-    background: linear-gradient(135deg, #0ea5e9, #0f172a);
-    display: grid;
-    place-items: center;
-    color: #e0f2fe;
-    font-weight: 800;
-    border: 1px solid rgba(148, 163, 184, 0.4);
-  }
-  .brand h1 { margin: 0; font-size: 20px; letter-spacing: 0.01em; }
-  .brand p { margin: 2px 0 0; color: var(--muted); font-size: 13px; }
-  .pill {
-    padding: 9px 14px;
-    border-radius: 999px;
-    border: 1px solid rgba(148, 163, 184, 0.2);
-    background: rgba(56, 189, 248, 0.1);
-    color: var(--text);
-    text-decoration: none;
-    font-size: 13px;
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-  }
-  main { padding: 22px; display: grid; gap: 14px; }
-  .panel {
-    background: rgba(10, 12, 20, 0.9);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 18px;
-    display: grid;
-    gap: 10px;
-  }
-  h2 { margin: 0; font-size: 17px; letter-spacing: 0.01em; }
-  p { margin: 0; color: var(--muted); }
-  label { display: block; font-size: 12px; color: var(--muted); margin-bottom: 6px; }
-  input[type="text"], input[type="password"] {
-    width: 100%;
-    border-radius: 12px;
-    border: 1px solid var(--border);
-    padding: 12px;
-    background: #070911;
-    color: var(--text);
-    font-size: 15px;
-  }
-  button {
-    border: none;
-    border-radius: 12px;
-    padding: 12px 14px;
-    background: var(--accent-strong);
-    color: #e0f2fe;
-    font-weight: 700;
-    cursor: pointer;
-    box-shadow: 0 8px 20px rgba(14,165,233,0.35);
-  }
-  button.secondary {
-    background: transparent;
-    border: 1px solid var(--border);
-    color: var(--text);
-    box-shadow: none;
-  }
-  .hint { font-size: 13px; color: var(--muted); }
-  .stack { display: grid; gap: 10px; }
-  .badge { padding: 6px 10px; border-radius: 10px; background: rgba(34,197,94,0.12); border: 1px solid rgba(34,197,94,0.4); color: #bbf7d0; font-size: 12px; width: fit-content; }
-  .danger { background: rgba(248,113,113,0.12); border-color: rgba(248,113,113,0.4); color: #fecdd3; }
-  .actions { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
-  .hidden { display: none; }
-</style>
+<link rel="stylesheet" href="/assets/base.css">
 <body>
-  <div class="shell">
-    <header>
-      <div class="brand">
-        <div class="logo">E</div>
-        <div>
-          <h1>Emperor News Admin</h1>
-          <p>管理者ログインと管理UI</p>
-        </div>
+  <header class="site-header">
+    <div class="brand">
+      <div class="logo">E</div>
+      <div>
+        <h1>Emperor News Admin</h1>
+        <p>管理者ログインと管理UI</p>
       </div>
+    </div>
+    <div class="actions">
       <a class="pill" href="/">公開サイトへ戻る</a>
-    </header>
+    </div>
+  </header>
 
-    <main>
-      <section class="panel" id="loginPanel">
-        <h2>ログイン</h2>
-        <p>ユーザー名とパスワードを入力してください。</p>
-        <form class="stack" id="loginForm">
-          <div>
-            <label for="username">ユーザー名</label>
-            <input id="username" name="username" type="text" autocomplete="username" placeholder="admin" required>
-          </div>
-          <div>
-            <label for="password">パスワード</label>
-            <input id="password" name="password" type="password" autocomplete="current-password" placeholder="admin" required>
-          </div>
-          <div class="actions">
-            <button type="submit">ログイン</button>
-            <p class="hint">初期認証情報: <strong>admin / admin</strong></p>
-          </div>
-        </form>
-        <div class="badge danger hidden" id="errorMessage">ユーザー名またはパスワードが違います。</div>
-      </section>
-
-      <section class="panel hidden" id="adminPanel">
-        <div class="actions" style="justify-content: space-between; align-items: flex-start; flex-wrap: wrap;">
-          <div class="stack">
-            <div class="badge" id="statusBadge">ログイン中</div>
-            <h2 style="margin-top:-4px;">管理UI</h2>
-            <p>ログイン済みの管理者のみが閲覧できます。記事編集やアップロードに進めます。</p>
-          </div>
-          <button class="secondary" id="logoutBtn">ログアウト</button>
+  <main class="container" style="max-width:780px;">
+    <section class="hero" id="loginPanel">
+      <div class="inline-chips">
+        <span class="badge">管理専用</span>
+        <span class="badge">スマホ / タブレット / PC</span>
+      </div>
+      <h2>ログイン</h2>
+      <p>ユーザー名とパスワードを入力してください。認証後は管理リンクが解放されます。</p>
+      <form class="stack" id="loginForm">
+        <div class="form-row">
+          <label for="username" class="tiny">ユーザー名</label>
+          <input id="username" name="username" type="text" autocomplete="username" placeholder="admin" required>
         </div>
+        <div class="form-row">
+          <label for="password" class="tiny">パスワード</label>
+          <input id="password" name="password" type="password" autocomplete="current-password" placeholder="admin" required>
+        </div>
+        <div class="actions">
+          <button type="submit" class="primary">ログイン</button>
+          <p class="tiny">初期認証情報: <strong>admin / admin</strong></p>
+        </div>
+      </form>
+      <div class="badge" style="display:none; background: rgba(248,113,113,0.18); color: #fecdd3;" id="errorMessage">ユーザー名またはパスワードが違います。</div>
+    </section>
+
+    <section class="hero" id="adminPanel" style="display:none;">
+      <div class="actions" style="justify-content: space-between; align-items: flex-start; flex-wrap: wrap;">
         <div class="stack">
-          <div class="actions">
-            <a class="pill" href="/blog-edit.html" id="openManager">記事編集ページ</a>
-            <a class="pill" href="/blog.html">公開ビューを開く</a>
-          </div>
-          <p class="hint">管理リンクは認証済みセッションでのみ利用できます。</p>
+          <div class="badge" id="statusBadge">ログイン中</div>
+          <h2 style="margin:0;">管理UI</h2>
+          <p class="muted">ログイン済みの管理者のみが閲覧できます。記事編集やアップロードに進めます。</p>
         </div>
-      </section>
-    </main>
-  </div>
+        <button class="secondary" id="logoutBtn">ログアウト</button>
+      </div>
+      <div class="stack">
+        <div class="actions">
+          <a class="pill primary" href="/blog-edit.html" id="openManager">記事編集ページ</a>
+          <a class="pill ghost" href="/blog.html">公開ビューを開く</a>
+        </div>
+        <p class="tiny">管理リンクは認証済みセッションでのみ利用できます。</p>
+      </div>
+    </section>
+  </main>
 
 <script>
   const SESSION_KEY = "emperor_admin_token";
@@ -193,13 +84,10 @@
   }
 
   function toggleView(authenticated) {
+    loginPanel.style.display = authenticated ? "none" : "grid";
+    adminPanel.style.display = authenticated ? "grid" : "none";
     if (authenticated) {
-      loginPanel.classList.add("hidden");
-      adminPanel.classList.remove("hidden");
       statusBadge.textContent = "ログイン中: admin";
-    } else {
-      adminPanel.classList.add("hidden");
-      loginPanel.classList.remove("hidden");
     }
   }
 
@@ -216,11 +104,11 @@
 
     if (username === "admin" && password === "admin") {
       setSession();
-      errorMessage.classList.add("hidden");
+      errorMessage.style.display = "none";
       toggleView(true);
       handleRedirectIfNeeded();
     } else {
-      errorMessage.classList.remove("hidden");
+      errorMessage.style.display = "inline-flex";
     }
   });
 

--- a/public/assets/base.css
+++ b/public/assets/base.css
@@ -1,0 +1,306 @@
+:root {
+  --bg: #030303;
+  --bg-alt: #060606;
+  --panel: #0c0c0c;
+  --panel-alt: #0f0f0f;
+  --text: #f5f5f5;
+  --muted: #a0a0a0;
+  --accent: #06c755;
+  --accent-2: #3b82f6;
+  --border: #1c1c1c;
+  --shadow: 0 24px 68px rgba(0, 0, 0, 0.45);
+  --radius-lg: 22px;
+  --radius: 14px;
+  --radius-sm: 10px;
+  --page-inline: clamp(16px, 4vw, 32px);
+  --page-max: 1200px;
+  --tablet: 720px;
+  --desktop: 1040px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Inter", "Noto Sans JP", system-ui, -apple-system, sans-serif;
+  color: var(--text);
+  background: radial-gradient(140% 120% at 18% 12%, rgba(6, 199, 85, 0.16), transparent),
+              radial-gradient(120% 120% at 82% 6%, rgba(59, 130, 246, 0.12), transparent),
+              var(--bg);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+a { color: inherit; }
+
+header.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  width: min(var(--page-max), 100%);
+  padding: 14px var(--page-inline);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  backdrop-filter: blur(12px);
+  background: rgba(4, 4, 4, 0.85);
+  border-bottom: 1px solid var(--border);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.logo {
+  width: 46px;
+  height: 46px;
+  border-radius: var(--radius);
+  display: grid;
+  place-items: center;
+  background: linear-gradient(145deg, #0d0d0d, #050505);
+  color: var(--accent);
+  font-weight: 800;
+  border: 1px solid var(--border);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.08);
+}
+
+.brand h1 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: 0.01em;
+}
+
+.brand p {
+  margin: 2px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.button, .pill, button.primary, button.secondary {
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  padding: 10px 14px;
+  background: var(--panel-alt);
+  color: var(--text);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.button.primary, .pill.primary, button.primary {
+  background: linear-gradient(135deg, var(--accent), #0ea34f);
+  color: #041902;
+  border-color: #0f2f14;
+  box-shadow: 0 12px 28px rgba(6, 199, 85, 0.35);
+}
+
+.button.ghost, .pill.ghost, button.secondary {
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  border-color: var(--border);
+  box-shadow: none;
+}
+
+.container {
+  width: min(var(--page-max), 100%);
+  padding: 18px var(--page-inline) 60px;
+  display: grid;
+  gap: 18px;
+}
+
+.hero {
+  background: linear-gradient(140deg, rgba(6, 199, 85, 0.18), rgba(6, 199, 85, 0.06) 38%, rgba(12, 12, 12, 0.92) 100%);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 14px;
+}
+
+.hero h2 { margin: 0; font-size: 24px; letter-spacing: 0.01em; }
+.hero p { margin: 0; color: var(--muted); line-height: 1.7; }
+
+.badge {
+  width: fit-content;
+  padding: 7px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.muted { color: var(--muted); }
+
+.card-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px;
+  display: grid;
+  gap: 10px;
+  box-shadow: 0 14px 38px rgba(0, 0, 0, 0.35);
+}
+
+.card h3 { margin: 0; font-size: 17px; }
+.card p { margin: 0; color: var(--muted); line-height: 1.6; }
+
+.section-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.section-title h2 { margin: 0; font-size: 20px; }
+
+.grid-2 {
+  display: grid;
+  gap: 14px;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+}
+
+.panel h3 { margin: 0 0 6px; }
+
+.input, input, textarea, select {
+  width: 100%;
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: #0a0a0a;
+  color: var(--text);
+  font-size: 15px;
+}
+
+textarea { resize: vertical; min-height: 140px; }
+
+.form-row { display: grid; gap: 8px; }
+
+.flex { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+
+.stack { display: grid; gap: 10px; }
+
+.tag-row { display: flex; gap: 8px; flex-wrap: wrap; }
+
+.tag { padding: 6px 10px; border-radius: 999px; border: 1px solid var(--border); background: #0c0c0c; font-size: 12px; }
+
+.tablet-hint, .pc-hint, .mobile-hint {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.device-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.device-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px;
+  background: linear-gradient(145deg, rgba(255,255,255,0.03), rgba(255,255,255,0.01));
+  display: grid;
+  gap: 6px;
+}
+
+.list-shell {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--panel);
+}
+
+.list-head {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.02);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.list { display: grid; }
+
+.list-card {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+  border-bottom: 1px solid var(--border);
+  transition: background 160ms ease, transform 160ms ease;
+}
+
+.list-card:last-child { border-bottom: none; }
+.list-card:hover { background: rgba(255,255,255,0.03); transform: translateY(-2px); }
+
+.thumb {
+  width: 100%;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: #0b0b0b;
+  aspect-ratio: 3/2;
+  object-fit: cover;
+}
+
+.thumb.fallback { display: grid; place-items: center; color: var(--muted); font-weight: 700; letter-spacing: 0.08em; }
+
+.tiny { font-size: 12px; color: var(--muted); }
+
+footer {
+  width: min(var(--page-max), 100%);
+  padding: 18px var(--page-inline) 24px;
+  color: var(--muted);
+  border-top: 1px solid var(--border);
+  background: rgba(4,4,4,0.8);
+}
+
+@media (max-width: 719px) {
+  header.site-header { flex-direction: column; align-items: flex-start; }
+  .container { padding: 16px 14px 54px; }
+  .section-title { flex-direction: column; align-items: flex-start; }
+}
+
+@media (min-width: var(--tablet)) {
+  .grid-2 { grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); }
+}
+
+@media (min-width: var(--desktop)) {
+  .split-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    gap: 16px;
+    align-items: start;
+  }
+}

--- a/public/assets/blog-shared.css
+++ b/public/assets/blog-shared.css
@@ -1,101 +1,29 @@
+@import url("/assets/base.css");
 
 :root {
-  --bg: #050505;
-  --panel: #0b0b0b;
-  --accent: #0f0f0f;
-  --text: #f7f7f7;
-  --muted: #9ca3af;
-  --line: #06c755;
-  --border: #1f1f1f;
-  --radius: 18px;
-  --shadow: 0 18px 50px rgba(0, 0, 0, 0.45);
-  --page-max: 1100px;
-  --page-inline: clamp(16px, 4vw, 30px);
+  --page-max: 1200px;
+  --page-inline: clamp(16px, 4vw, 32px);
 }
-
-* { box-sizing: border-box; }
 
 body {
-  margin: 0;
-  font-family: "SF Pro Display", "Inter", "Noto Sans JP", system-ui, sans-serif;
-  background: radial-gradient(140% 120% at 20% 10%, rgba(6, 199, 85, 0.12), transparent),
-              radial-gradient(120% 120% at 80% 0%, rgba(6, 199, 85, 0.08), transparent),
+  background: radial-gradient(140% 120% at 18% 12%, rgba(6, 199, 85, 0.2), transparent),
+              radial-gradient(120% 120% at 82% 6%, rgba(6, 199, 85, 0.12), transparent),
               var(--bg);
-  color: var(--text);
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
 }
 
-a { color: inherit; }
-
-header {
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  backdrop-filter: blur(12px);
-  background: rgba(5, 5, 5, 0.9);
-  border-bottom: 1px solid var(--border);
-  padding: 14px var(--page-inline);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  width: min(var(--page-max), 100%);
+header.site-header {
+  background: rgba(4, 4, 4, 0.9);
 }
 
-.brand { display: flex; align-items: center; gap: 10px; }
-
-.logo {
-  width: 42px;
-  height: 42px;
-  border-radius: 14px;
-  border: 1px solid var(--border);
+.hero-grid {
   display: grid;
-  place-items: center;
-  background: linear-gradient(145deg, #0f0f0f, #0a0a0a);
-  color: var(--line);
-  font-weight: 700;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
-.brand h1 { margin: 0; font-size: 18px; letter-spacing: 0.01em; }
-.brand p { margin: 2px 0 0; color: var(--muted); font-size: 12px; }
+.inline-chips { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
 
-.pill {
-  padding: 9px 14px;
-  border-radius: 999px;
-  border: 1px solid var(--border);
-  background: var(--accent);
-  text-decoration: none;
-  font-size: 13px;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.pill.primary { background: var(--line); color: #041902; font-weight: 700; border-color: #0f2f14; }
-
-.actions {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-}
-
-.badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 10px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid var(--border);
-  color: #cbd5e1;
-  font-size: 12px;
-}
-
-.tag { padding: 6px 10px; border-radius: 999px; border: 1px solid var(--border); background: #0c0c0c; font-size: 12px; }
+.meta { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; color: var(--muted); font-size: 12px; }
 
 .share,
 .share-btn,
@@ -107,51 +35,56 @@ header {
   gap: 6px;
   border-radius: 10px;
   border: 1px solid var(--border);
-  padding: 8px 12px;
+  padding: 10px 12px;
   background: #0c0c0c;
   color: var(--text);
   font-size: 13px;
 }
 
 .share.line,
-.share-btn.line { background: var(--line); color: #041902; font-weight: 700; border-color: #0f2f14; }
+.share-btn.line { background: var(--accent); color: #041902; font-weight: 700; border-color: #0f2f14; }
 
-.meta { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; color: var(--muted); font-size: 12px; }
-
-main,
-footer {
-  width: min(var(--page-max), 100%);
+.scroll-shell {
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: #0b0b0b;
 }
 
-@media (max-width: 720px) {
-  header { flex-direction: column; align-items: flex-start; }
+.scroll-track {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 86%;
+  gap: 12px;
+  overflow-x: auto;
+  padding: 12px;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
 }
 
-@media (min-width: 740px) {
-  header { gap: 16px; }
-}
+.scroll-track::-webkit-scrollbar { height: 8px; }
+.scroll-track::-webkit-scrollbar-thumb { background: #1f1f1f; border-radius: 999px; }
 
-body.is-mobile {
-  align-items: stretch;
-}
-
-body.is-mobile header,
-body.is-mobile main,
-body.is-mobile footer {
-  width: 100%;
-  max-width: none;
-}
-
-body.is-mobile header {
-  padding: 12px 16px;
+.article-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px;
+  display: grid;
   gap: 10px;
+  box-shadow: 0 12px 32px rgba(0,0,0,0.3);
+  scroll-snap-align: start;
 }
 
-body.is-mobile .actions {
-  width: 100%;
-  justify-content: flex-start;
-}
+.hero-img { width: 100%; border-radius: 14px; aspect-ratio: 16 / 9; object-fit: cover; border: 1px solid var(--border); }
 
-body.is-mobile .pill {
-  width: auto;
-}
+.article-body { display: grid; gap: 10px; line-height: 1.7; color: #e5e7eb; }
+
+.ticker { display: flex; gap: 10px; overflow: hidden; border: 1px solid var(--border); border-radius: 14px; background: #080808; padding: 8px 10px; }
+.ticker-track { display: flex; gap: 10px; animation: marquee 26s linear infinite; }
+.chip { padding: 7px 12px; border-radius: 999px; border: 1px solid var(--border); background: #0d0d0d; color: var(--muted); white-space: nowrap; }
+
+@keyframes marquee { 0% { transform: translateX(0); } 100% { transform: translateX(-50%); } }
+
+@media (min-width: 720px) { .scroll-track { grid-auto-columns: 64%; } }
+@media (min-width: 1024px) { .scroll-track { grid-auto-columns: 42%; } }

--- a/public/blog-article.html
+++ b/public/blog-article.html
@@ -2,161 +2,96 @@
 <html lang="ja">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>記事ビュー | Emperor News</title>
+<title>記事ページ | Emperor News</title>
 <link rel="stylesheet" href="/assets/blog-shared.css">
-<style>
-  main { padding: 22px var(--page-inline) 40px; display: grid; gap: 16px; width: 100%; }
-  .hero {
-    background: linear-gradient(130deg, rgba(6,199,85,0.16), rgba(6,199,85,0.05) 35%, rgba(8,8,8,0.95));
-    border: 1px solid var(--border);
-    border-radius: 24px;
-    padding: 18px;
-    display: grid;
-    gap: 12px;
-    box-shadow: var(--shadow);
-  }
-  .hero h2 { margin: 0; font-size: 24px; letter-spacing: 0.01em; }
-  .hero p { margin: 0; color: var(--muted); line-height: 1.7; }
-  .meta-row { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; color: var(--muted); font-size: 12px; }
-  .chip { padding: 6px 10px; border-radius: 999px; border: 1px solid var(--border); background: rgba(255,255,255,0.04); }
-
-  .article-card {
-    background: var(--panel);
-    border: 1px solid var(--border);
-    border-radius: 20px;
-    padding: 16px;
-    display: grid;
-    gap: 14px;
-    box-shadow: var(--shadow);
-  }
-  .cover {
-    width: 100%;
-    border-radius: 16px;
-    aspect-ratio: 16 / 9;
-    object-fit: cover;
-    border: 1px solid var(--border);
-  }
-  .title-block h3 { margin: 0; font-size: 22px; }
-  .title-block p { margin: 6px 0 0; color: var(--muted); line-height: 1.6; }
-  .tag-row { display: flex; gap: 8px; flex-wrap: wrap; }
-  .body { display: grid; gap: 12px; line-height: 1.7; color: #e5e7eb; }
-  .body p { margin: 0; }
-
-  .share-row { display: flex; gap: 10px; flex-wrap: wrap; }
-  .share:active { transform: translateY(1px); }
-
-  footer { padding: 0 18px 24px; color: var(--muted); font-size: 12px; }
-</style>
 <body>
-  <header>
+  <header class="site-header">
     <div class="brand">
       <div class="logo">E</div>
       <div>
-        <h1>Emperor News</h1>
-        <p>記事ビュー / 黒ベースのシンプル読書体験</p>
+        <h1>記事ページ</h1>
+        <p>スマホ・タブレット・PCの本文ビュー</p>
       </div>
     </div>
     <div class="actions">
-      <a class="pill" href="/blog.html">公開一覧</a>
-      <a class="pill" href="/">トップ</a>
+      <a class="pill" href="/blog.html">一覧へ</a>
+      <a class="pill ghost" href="/blog-list.html">リストビュー</a>
     </div>
   </header>
 
-  <main>
-    <section class="hero">
-      <div class="meta-row">
-        <span class="chip">公開記事</span>
-        <span class="chip">LINE公式シェア対応</span>
-      </div>
-      <h2 id="heroTitle">記事タイトル</h2>
-      <p id="heroLead">記事本文の冒頭をここに表示します。iPhone / iPadのダークモードに合わせた黒基調のレイアウトです。</p>
-      <div class="share-row">
-        <a class="share line" id="lineShare" target="_blank" rel="noreferrer">公式LINEで共有</a>
-        <a class="share" id="copyLink" href="#">リンクをコピー</a>
-      </div>
+  <main class="container">
+    <section class="hero" id="articleHero">
+      <div class="inline-chips" id="articleMeta"></div>
+      <h2 id="articleTitle">記事タイトル</h2>
+      <p id="articleLead" class="muted">本文の冒頭をここに表示します。</p>
+      <div class="actions" id="shareRow"></div>
     </section>
 
-    <article class="article-card" id="article">
-      <img class="cover" id="cover" alt="カバー画像">
-      <div class="title-block">
-        <h3 id="title">記事タイトル</h3>
-        <p id="excerpt">記事の概要テキストを表示します。</p>
-      </div>
-      <div class="tag-row" id="tags"></div>
-      <div class="body" id="body"></div>
-    </article>
+    <section class="grid-2">
+      <article class="card" id="articleBody"></article>
+      <aside class="card">
+        <h3>デバイス別の読みやすさ</h3>
+        <div class="device-grid">
+          <div class="device-card">
+            <strong>スマホ</strong>
+            <span class="mobile-hint">本文を1カラムで表示し、ボタンを大きめに。</span>
+          </div>
+          <div class="device-card">
+            <strong>タブレット</strong>
+            <span class="tablet-hint">本文幅を少し広げ、サイド余白を確保。</span>
+          </div>
+          <div class="device-card">
+            <strong>PC</strong>
+            <span class="pc-hint">最大1200pxのカラムで視線移動を最小化。</span>
+          </div>
+        </div>
+      </aside>
+    </section>
   </main>
-
-  <footer>
-    Emperor News — 公式LINEアカウント連携ビュー
-  </footer>
 
 <script src="/assets/blog-data.js"></script>
 <script>
-  function loadArticles() {
-    return BlogData.loadArticles();
-  }
+  const params = new URLSearchParams(location.search);
+  const articleIdx = parseInt(params.get("id"), 10) || 0;
+  const { article } = BlogData.findArticle(articleIdx);
 
-  async function findArticle() {
-    const params = new URLSearchParams(location.search);
-    const idx = parseInt(params.get("id"), 10);
-    const list = loadArticles();
-    const isValidIdx = Number.isFinite(idx) && list[idx];
-    const article = isValidIdx ? list[idx] : list[0];
-    return { article, list, idx: isValidIdx ? idx : 0 };
-  }
+  function renderArticle() {
+    const hero = document.getElementById("articleHero");
+    const titleEl = document.getElementById("articleTitle");
+    const leadEl = document.getElementById("articleLead");
+    const bodyEl = document.getElementById("articleBody");
+    const shareRow = document.getElementById("shareRow");
+    const meta = document.getElementById("articleMeta");
 
-  function paragraphize(text) {
-    if (!text) return ["本文が追加されていません。管理画面から本文を入れてください。"];
-    return text.split(/\n{2,}/).map(chunk => chunk.trim()).filter(Boolean);
-  }
+    titleEl.textContent = article.title || "無題の記事";
+    leadEl.textContent = article.body?.slice(0, 120) || "本文を入力してください";
 
-  function render(article, idx) {
-    const safeBody = paragraphize(article.body);
-    const cover = document.getElementById("cover");
-    const title = document.getElementById("title");
-    const heroTitle = document.getElementById("heroTitle");
-    const heroLead = document.getElementById("heroLead");
-    const excerpt = document.getElementById("excerpt");
-    const tags = document.getElementById("tags");
-    const body = document.getElementById("body");
-    const lineShare = document.getElementById("lineShare");
-
-    title.textContent = article.title || "無題の記事";
-    heroTitle.textContent = article.title || "無題の記事";
-    heroLead.textContent = safeBody[0] || "本文がありません。";
-    excerpt.textContent = safeBody[0] || "本文がありません。";
-
-    tags.innerHTML = (article.tags || []).length
-      ? article.tags.map(tag => `<span class="tag">#${tag}</span>`).join("")
-      : '<span class="tag">#untagged</span>';
-
-    body.innerHTML = safeBody.map(p => `<p>${p}</p>`).join("");
+    meta.innerHTML = `
+      <span class="badge">ID ${articleIdx}</span>
+      <span class="badge">レスポンシブ本文</span>
+      ${(article.tags || []).map(tag => `<span class=\"badge\">#${tag}</span>`).join("")}
+    `;
 
     if (article.image) {
-      cover.src = article.image;
-      cover.alt = article.title;
-      cover.style.display = "block";
-    } else {
-      cover.style.display = "none";
+      const img = document.createElement("img");
+      img.src = article.image;
+      img.alt = article.title;
+      img.className = "hero-img";
+      hero.appendChild(img);
     }
 
-    const canonical = `${location.origin}${location.pathname}?id=${idx}`;
-    lineShare.href = BlogData.buildOfficialLineShare(canonical);
-    lineShare.textContent = `${BlogData.officialLineAccountId} で共有`;
+    bodyEl.classList.add("article-body");
+    bodyEl.innerHTML = (article.body || "本文がありません").split(/\n+/).map(p => `<p>${p}</p>`).join("");
 
-    document.getElementById("copyLink").addEventListener("click", (e) => {
-      e.preventDefault();
-      navigator.clipboard?.writeText(canonical).then(() => {
-        alert("記事リンクをコピーしました。LINEに貼り付けて共有できます。");
-      }).catch(() => alert("コピーに失敗しました"));
-    });
+    const articleUrl = `${location.origin}/blog-article.html?id=${articleIdx}`;
+    const shareUrl = BlogData.buildOfficialLineShare(articleUrl);
+    shareRow.innerHTML = `
+      <a class="share line" href="${shareUrl}" target="_blank" rel="noreferrer">LINEで共有</a>
+      <a class="share" href="${articleUrl}" target="_blank">リンクをコピー</a>
+    `;
   }
 
-  document.addEventListener("DOMContentLoaded", async () => {
-    const { article, idx } = await findArticle();
-    render(article, idx);
-  });
+  document.addEventListener("DOMContentLoaded", renderArticle);
 </script>
 </body>
 </html>

--- a/public/blog-edit.html
+++ b/public/blog-edit.html
@@ -3,51 +3,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>記事編集 | Emperor News</title>
-<link rel="stylesheet" href="/assets/blog-shared.css">
-<style>
-  body { background: radial-gradient(circle at 14% 12%, rgba(6,199,85,0.16), transparent 38%), var(--bg); }
-  main { padding: 22px 18px 48px; display: grid; gap: 18px; }
-  .stack { display: grid; gap: 12px; }
-  .panel {
-    background: rgba(10,12,20,0.9);
-    border: 1px solid var(--border);
-    border-radius: 18px;
-    padding: 16px;
-    box-shadow: var(--shadow);
-  }
-  .panel h2 { margin: 0 0 4px; font-size: 18px; }
-  .panel p { margin: 0 0 10px; color: var(--muted); }
-  label { display: block; font-size: 12px; color: var(--muted); margin-bottom: 6px; }
-  input, textarea {
-    width: 100%;
-    border-radius: 12px;
-    border: 1px solid var(--border);
-    background: #090b12;
-    color: #f8fafc;
-    padding: 12px;
-    font-size: 15px;
-  }
-  textarea { min-height: 160px; resize: vertical; }
-  .actions { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
-  button { border: none; border-radius: 12px; padding: 12px 14px; font-weight: 700; cursor: pointer; }
-  button.primary { background: #16a34a; color: #ecfdf3; box-shadow: 0 8px 20px rgba(22,163,74,0.35); }
-  button.secondary { background: transparent; border: 1px solid var(--border); color: var(--text); }
-  .list { display: grid; gap: 10px; }
-  .item {
-    border: 1px solid var(--border);
-    border-radius: 14px;
-    padding: 12px;
-    background: linear-gradient(120deg, rgba(6,199,85,0.12), rgba(6,199,85,0.04));
-    display: grid;
-    gap: 6px;
-  }
-  .item h3 { margin: 0; font-size: 16px; }
-  .badge { padding: 6px 10px; border-radius: 10px; background: rgba(6,199,85,0.12); border: 1px solid rgba(6,199,85,0.35); color: #bbf7d0; font-size: 12px; width: fit-content; }
-  .muted { color: var(--muted); font-size: 13px; margin: 0; }
-  .tag-row { display: flex; gap: 6px; flex-wrap: wrap; }
-  .tag-row .tag { background: rgba(255,255,255,0.05); border: 1px solid var(--border); }
-  .empty { color: var(--muted); font-size: 14px; }
-</style>
+<link rel="stylesheet" href="/assets/base.css">
 <body>
   <script>
     (function enforceAdminSession() {
@@ -60,7 +16,7 @@
     })();
   </script>
 
-  <header>
+  <header class="site-header">
     <div class="brand">
       <div class="logo">E</div>
       <div>
@@ -70,49 +26,54 @@
     </div>
     <div class="actions">
       <a class="pill" href="/blog.html">公開一覧へ戻る</a>
-      <a class="pill" href="/admin.html">認証ページ</a>
+      <a class="pill ghost" href="/admin.html">認証ページ</a>
     </div>
   </header>
 
-  <main>
-    <section class="panel stack">
-      <div class="actions" style="justify-content: space-between; align-items: flex-start; flex-wrap: wrap;">
-        <div class="stack">
-          <div class="badge" id="status">ログイン中</div>
-          <h2 style="margin:0">記事の新規追加・編集</h2>
-          <p style="margin:0">タイトル・本文・タグ・カバー画像URLを入力して保存します。</p>
-        </div>
-        <button class="secondary" id="newBtn">新規作成</button>
+  <main class="container">
+    <section class="hero">
+      <div class="inline-chips">
+        <div class="badge" id="status">ログイン中</div>
+        <div class="badge">スマホ〜PC対応</div>
       </div>
+      <h2 style="margin:0">記事の新規追加・編集</h2>
+      <p class="muted">タイトル・本文・タグ・カバー画像URLを入力して保存します。フォームやリストはすべてレスポンシブに配置しました。</p>
+      <div class="actions" style="justify-content: space-between; align-items: flex-start;">
+        <button class="secondary" id="newBtn">新規作成</button>
+        <p class="tiny" id="helper">新しい記事を作成します。</p>
+      </div>
+    </section>
 
+    <section class="panel stack">
       <form class="stack" id="editorForm">
-        <div>
-          <label for="title">タイトル</label>
+        <div class="form-row">
+          <label for="title" class="tiny">タイトル</label>
           <input id="title" name="title" required placeholder="記事タイトル">
         </div>
-        <div>
-          <label for="body">本文 (複数段落は空行で区切ってください)</label>
+        <div class="form-row">
+          <label for="body" class="tiny">本文 (複数段落は空行で区切ってください)</label>
           <textarea id="body" name="body" required placeholder="本文を入力"></textarea>
         </div>
-        <div>
-          <label for="tags">タグ (カンマ区切り)</label>
+        <div class="form-row">
+          <label for="tags" class="tiny">タグ (カンマ区切り)</label>
           <input id="tags" name="tags" placeholder="iPhone, iPad, 公式LINE">
         </div>
-        <div>
-          <label for="image">カバー画像URL</label>
+        <div class="form-row">
+          <label for="image" class="tiny">カバー画像URL</label>
           <input id="image" name="image" type="url" placeholder="https://example.com/cover.jpg">
         </div>
         <div class="actions">
           <button class="primary" type="submit" id="saveBtn">保存する</button>
-          <p class="muted" id="helper">新しい記事を作成します。</p>
         </div>
       </form>
     </section>
 
     <section class="panel">
-      <h2>保存済みの記事</h2>
-      <p class="muted">ローカル保存された記事を編集または削除できます。</p>
-      <div class="list" id="articleList"></div>
+      <div class="section-title">
+        <h3>保存済みの記事</h3>
+        <span class="tiny">ローカル保存された記事を編集または削除できます。</span>
+      </div>
+      <div class="stack" id="articleList"></div>
     </section>
   </main>
 
@@ -127,7 +88,7 @@
   let editingIdx = null;
 
   function parseTags(input) {
-    return input.split(/[,\n]/).map(t => t.trim()).filter(Boolean);
+    return input.split(/[\,\n]/).map(t => t.trim()).filter(Boolean);
   }
 
   function formatTags(tags) {
@@ -143,17 +104,21 @@
     const articles = BlogData.loadArticles();
     articleList.innerHTML = "";
     if (!articles.length) {
-      articleList.innerHTML = '<p class="empty">まだ記事がありません。フォームから追加してください。</p>';
+      articleList.innerHTML = '<p class="muted">まだ記事がありません。フォームから追加してください。</p>';
       return;
     }
 
     articles.forEach((article, idx) => {
       const item = document.createElement("div");
-      item.className = "item";
+      item.className = "card";
       item.innerHTML = `
-        <div class="actions" style="justify-content: space-between; align-items: flex-start;">
-          <div class="stack" style="gap:4px;">
-            <h3>${article.title || "無題の記事"}</h3>
+        <div class="actions" style="justify-content: space-between; align-items: flex-start; flex-wrap: wrap;">
+          <div class="stack" style="gap:6px;">
+            <div class="inline-chips">
+              <span class="badge">ID ${idx}</span>
+              <span class="badge">${(article.tags || []).length || 0} タグ</span>
+            </div>
+            <h3 style="margin:0;">${article.title || "無題の記事"}</h3>
             <p class="muted">${article.body?.slice(0, 80) || "本文がありません"}</p>
             <div class="tag-row">${(article.tags || []).map(tag => `<span class="tag">#${tag}</span>`).join("") || '<span class="tag">#untagged</span>'}</div>
           </div>

--- a/public/blog-list.html
+++ b/public/blog-list.html
@@ -4,293 +4,84 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Emperor News — 一覧ビュー</title>
 <link rel="stylesheet" href="/assets/blog-shared.css">
-<style>
-  main {
-    padding: 22px var(--page-inline) 70px;
-    display: grid;
-    gap: 18px;
-  }
-
-  .intro-grid {
-    display: grid;
-    gap: 14px;
-  }
-
-  .hero {
-    background: linear-gradient(135deg, rgba(6, 199, 85, 0.14), rgba(6, 199, 85, 0.04) 40%, rgba(12, 12, 12, 0.9) 100%);
-    border: 1px solid var(--border);
-    border-radius: 24px;
-    padding: 18px 18px 20px;
-    display: grid;
-    gap: 12px;
-    box-shadow: var(--shadow);
-  }
-
-  .hero h2 { margin: 0; font-size: 22px; letter-spacing: 0.01em; }
-  .hero p { margin: 0; color: var(--muted); line-height: 1.6; }
-
-  .hero-foot {
-    display: flex;
-    gap: 10px;
-    flex-wrap: wrap;
-    align-items: center;
-  }
-
-  .mini-pill {
-    font-size: 12px;
-    padding: 6px 10px;
-    border-radius: 999px;
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid var(--border);
-    color: var(--muted);
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-  }
-
-  .list-layout {
-    display: grid;
-    gap: 14px;
-  }
-
-  .list-shell {
-    background: #090909;
-    border: 1px solid var(--border);
-    border-radius: 20px;
-    overflow: hidden;
-    box-shadow: var(--shadow);
-  }
-
-  .list-head {
-    padding: 14px 16px;
-    border-bottom: 1px solid var(--border);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    flex-wrap: wrap;
-  }
-
-  .list-head h3 { margin: 0; font-size: 16px; letter-spacing: 0.01em; }
-  .list-head p { margin: 0; color: var(--muted); font-size: 13px; }
-
-  .list {
-    display: grid;
-  }
-
-  .list-card {
-    padding: 16px;
-    display: grid;
-    gap: 12px;
-    border-bottom: 1px solid var(--border);
-    transition: background 180ms ease, transform 180ms ease;
-  }
-
-  .list-card:hover { background: rgba(255, 255, 255, 0.02); transform: translateY(-2px); }
-
-  .list-card:last-child { border-bottom: none; }
-
-  .list-content {
-    display: grid;
-    gap: 10px;
-  }
-
-  .list-meta {
-    display: flex;
-    gap: 8px;
-    flex-wrap: wrap;
-    align-items: center;
-    color: var(--muted);
-    font-size: 12px;
-  }
-
-  .list-title { margin: 0; font-size: 18px; letter-spacing: 0.01em; }
-  .list-excerpt { margin: 0; color: var(--muted); line-height: 1.6; font-size: 14px; }
-
-  .list-actions {
-    display: flex;
-    gap: 10px;
-    flex-wrap: wrap;
-    align-items: center;
-  }
-
-  .thumb {
-    width: 100%;
-    border-radius: 14px;
-    border: 1px solid var(--border);
-    background: #0c0c0c;
-    aspect-ratio: 3 / 2;
-    object-fit: cover;
-    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.3);
-  }
-
-  .thumb.fallback {
-    display: grid;
-    place-items: center;
-    color: var(--muted);
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    background: linear-gradient(135deg, #0e0e0e, #0a0a0a);
-  }
-
-  .aside {
-    display: grid;
-    gap: 12px;
-  }
-
-  .panel {
-    background: #0a0a0a;
-    border: 1px solid var(--border);
-    border-radius: 18px;
-    padding: 14px;
-    display: grid;
-    gap: 10px;
-  }
-
-  .stats-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    gap: 12px;
-  }
-
-  .stat {
-    padding: 12px;
-    border-radius: 14px;
-    border: 1px solid var(--border);
-    background: #0c0c0c;
-    display: grid;
-    gap: 6px;
-  }
-
-  .stat h4 { margin: 0; font-size: 14px; color: var(--muted); }
-  .stat strong { font-size: 20px; letter-spacing: 0.02em; }
-
-  .tag-cloud {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-  }
-
-  .device-hints {
-    display: grid;
-    gap: 8px;
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  }
-
-  .hint {
-    padding: 10px 12px;
-    border-radius: 12px;
-    border: 1px solid var(--border);
-    background: rgba(255, 255, 255, 0.03);
-    color: var(--muted);
-    font-size: 13px;
-    display: grid;
-    gap: 4px;
-  }
-
-  @media (min-width: 640px) {
-    .list-card {
-      grid-template-columns: 170px 1fr;
-      align-items: center;
-    }
-
-    .list-content { gap: 12px; }
-  }
-
-  @media (min-width: 960px) {
-    .list-layout {
-      grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr);
-      align-items: start;
-    }
-
-    .aside { position: sticky; top: 84px; }
-  }
-</style>
 <body>
-  <header>
+  <header class="site-header">
     <div class="brand">
       <div class="logo">E</div>
       <div>
         <h1>Emperor News</h1>
-        <p>一覧ビュー / モバイル・タブレット・PC対応</p>
+        <p>一覧ビュー / スマホ・タブレット・PC対応</p>
       </div>
     </div>
     <div class="actions">
       <a class="pill" href="/">トップ</a>
       <a class="pill" href="/blog.html">カードビュー</a>
-      <a class="pill" id="openLine" target="_blank" rel="noreferrer">公式LINEで読む</a>
-      <a class="pill" href="/blog-edit.html" data-requires-auth="true">記事を編集</a>
+      <a class="pill primary" id="openLine" target="_blank" rel="noreferrer">公式LINEで読む</a>
+      <a class="pill ghost" href="/blog-edit.html" data-requires-auth="true">記事を編集</a>
     </div>
   </header>
 
-  <main>
-    <section class="intro-grid">
-      <div class="hero">
-        <div class="mini-pill">新設 / 一覧レイアウト</div>
-        <h2>端末幅に合わせて読める一覧ビュー</h2>
-        <p>スマホでは縦積み、タブレットではサムネイル横並び、PCではサイド情報付きの2カラムで記事を探せます。黒基調とLINE共有ボタンは既存ビューと共通です。</p>
-        <div class="hero-foot">
-          <span class="mini-pill" id="metaInfo"></span>
-          <span class="mini-pill">LINE連携</span>
-          <span class="mini-pill">ローカル保存</span>
-        </div>
+  <main class="container">
+    <section class="hero">
+      <div class="inline-chips">
+        <div class="badge">新設</div>
+        <div class="badge">レスポンシブ</div>
       </div>
-
-      <div class="panel">
-        <div class="list-head" style="padding:0">
-          <div>
-            <h3>デバイス別の見え方</h3>
-            <p>スマホ・タブレット・PCの幅に応じて、自動で余白とレイアウトを再配置します。</p>
-          </div>
-        </div>
-        <div class="device-hints">
-          <div class="hint">
-            <strong>スマホ</strong>
-            <span>サムネイルは縦に配置。1列カードでタップしやすい余白。</span>
-          </div>
-          <div class="hint">
-            <strong>タブレット</strong>
-            <span>サムネイルと本文を2カラム化。行間を少し拡大。</span>
-          </div>
-          <div class="hint">
-            <strong>PC</strong>
-            <span>右側に統計とタグクラウドのサイドバーを表示。最大幅を1100pxに制限。</span>
-          </div>
-        </div>
+      <h2>幅に合わせて表情を変える一覧ビュー</h2>
+      <p>スマホでは縦にカードを並べ、タブレットはサムネイル横並び、PCではサイドバー付きの2カラムで統計とタグクラウドを固定。見やすさを保ちながら情報量を増やしました。</p>
+      <div class="inline-chips">
+        <span class="badge" id="metaInfo"></span>
+        <span class="badge">LINE連携</span>
+        <span class="badge">ローカル保存</span>
       </div>
     </section>
 
-    <section class="list-layout">
+    <section class="grid-2">
+      <article class="card">
+        <h3>スマホビュー</h3>
+        <p class="mobile-hint">1カラムでサムネイルを上、本文とタグを下に配置。タップしやすい余白を確保しました。</p>
+      </article>
+      <article class="card">
+        <h3>タブレットビュー</h3>
+        <p class="tablet-hint">サムネイル横並び＋行間拡大。768px以上で自動適用されます。</p>
+      </article>
+      <article class="card">
+        <h3>PCビュー</h3>
+        <p class="pc-hint">最大幅1200pxで2カラム＋サイドバーを固定。タグクラウドと統計を右側に表示します。</p>
+      </article>
+      <article class="card">
+        <h3>共有と導線</h3>
+        <p>各記事にLINE共有と記事リンクを配置。管理者リンクは認証が必要な場合のみ遷移します。</p>
+      </article>
+    </section>
+
+    <section class="split-layout">
       <div class="list-shell">
         <div class="list-head">
           <div>
             <h3>最新の投稿</h3>
-            <p>ローカル保存された記事を時系列順に一覧表示します。</p>
+            <p class="muted">ローカル保存された記事を時系列順に一覧表示します。</p>
           </div>
-          <div class="mini-pill" id="countBadge"></div>
+          <div class="badge" id="countBadge"></div>
         </div>
         <div class="list" id="list"></div>
       </div>
 
-      <aside class="aside" aria-label="サイド情報">
+      <aside class="stack" aria-label="サイド情報">
         <div class="panel">
-          <div class="list-head" style="padding:0">
-            <div>
-              <h3>ビューのステータス</h3>
-              <p>タブレット・PCで横に並ぶカード。</p>
-            </div>
+          <div class="section-title" style="gap:6px;">
+            <h3>ビューのステータス</h3>
+            <span class="tiny">タブレット以上で右カラムに固定</span>
           </div>
-          <div class="stats-grid" id="stats"></div>
+          <div class="card-grid" id="stats"></div>
         </div>
 
         <div class="panel">
-          <div class="list-head" style="padding:0">
-            <div>
-              <h3>タグクラウド</h3>
-              <p>よく使うタグを確認できます。</p>
-            </div>
+          <div class="section-title" style="gap:6px;">
+            <h3>タグクラウド</h3>
+            <span class="tiny">使用頻度順に表示</span>
           </div>
-          <div class="tag-cloud" id="tagCloud"></div>
+          <div class="tag-row" id="tagCloud"></div>
         </div>
       </aside>
     </section>
@@ -340,17 +131,17 @@
         const hasImage = Boolean(item.image);
         card.innerHTML = `
           ${hasImage ? `<img class="thumb" src="${item.image}" alt="${item.title}">` : `<div class="thumb fallback">NO IMAGE</div>`}
-          <div class="list-content">
-            <div class="list-meta">
-              <span class="mini-pill">#${idx + 1}</span>
-              <span class="mini-pill">${formatRelative(idx)}に更新</span>
+          <div class="stack" style="gap:12px;">
+            <div class="inline-chips">
+              <span class="badge">#${idx + 1}</span>
+              <span class="badge">${formatRelative(idx)}に更新</span>
             </div>
-            <h3 class="list-title">${item.title}</h3>
-            <p class="list-excerpt">${item.body}</p>
+            <h3 style="margin:0; font-size:18px; letter-spacing:0.01em;">${item.title}</h3>
+            <p class="muted">${item.body}</p>
             <div class="meta">
               ${(item.tags || []).map(t => `<span class="tag">#${t}</span>`).join("") || '<span class="tag">#untagged</span>'}
             </div>
-            <div class="list-actions">
+            <div class="actions">
               <a class="share line" href="${shareUrl}" target="_blank" rel="noreferrer">LINEで共有</a>
               <a class="share" href="${articleUrl}" target="_blank">記事ページ</a>
             </div>
@@ -364,13 +155,13 @@
       statsEl.innerHTML = "";
       const statItems = [
         { label: "記事数", value: `${list.length} 件` },
-        { label: "スマホ/タブレット対応", value: "横2列⇔縦1列が自動切替" },
+        { label: "スマホ/タブレット対応", value: "横2列⇔縦1列 自動切替" },
         { label: "LINE共有", value: "公式アカウントへ誘導" },
       ];
       statItems.forEach((item) => {
         const box = document.createElement("div");
-        box.className = "stat";
-        box.innerHTML = `<h4>${item.label}</h4><strong>${item.value}</strong>`;
+        box.className = "card";
+        box.innerHTML = `<h3>${item.label}</h3><p class="muted">${item.value}</p>`;
         statsEl.appendChild(box);
       });
     }
@@ -383,7 +174,7 @@
       });
       const entries = [...counts.entries()].sort((a, b) => b[1] - a[1]);
       if (!entries.length) {
-        tagCloud.innerHTML = '<span class="mini-pill">タグが未設定です</span>';
+        tagCloud.innerHTML = '<span class="badge">タグが未設定です</span>';
         return;
       }
       entries.forEach(([tag, count]) => {

--- a/public/blog-public.html
+++ b/public/blog-public.html
@@ -4,65 +4,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Emperor News — 公開ビュー (旧)</title>
 <link rel="stylesheet" href="/assets/blog-shared.css">
-<style>
-  :root {
-    --panel: #0a0a0a;
-    --accent: #1a1a1a;
-  }
-  body {
-    background: radial-gradient(160% 140% at 20% 20%, rgba(6,199,85,0.12), transparent),
-                radial-gradient(120% 120% at 80% 0%, rgba(6,199,85,0.08), transparent),
-                var(--bg);
-  }
-  main { padding: 22px 18px 48px; display: grid; gap: 20px; }
-  .hero {
-    background: linear-gradient(135deg, rgba(6,199,85,0.18), rgba(6,199,85,0.05) 32%, rgba(12,12,12,0.9) 100%);
-    border: 1px solid var(--border);
-    border-radius: 26px;
-    padding: 20px;
-    display: grid;
-    gap: 12px;
-    box-shadow: var(--shadow);
-  }
-  .hero h2 { margin: 0; font-size: 22px; }
-  .hero p { margin: 0; color: var(--muted); line-height: 1.6; }
-  .hero .cta-row { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
-  .mini-pill { font-size: 12px; padding: 6px 10px; border-radius: 999px; background: rgba(255,255,255,0.05); border: 1px solid var(--border); color: var(--muted); }
-
-  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 14px; }
-  .card {
-    background: var(--panel);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 14px;
-    display: grid;
-    gap: 10px;
-    box-shadow: 0 12px 32px rgba(0,0,0,0.3);
-    transition: transform 220ms ease, border-color 200ms ease;
-  }
-  .card:hover { transform: translateY(-4px); border-color: rgba(6,199,85,0.4); }
-  .card h3 { margin: 0; font-size: 17px; letter-spacing: 0.01em; }
-  .card p { margin: 0; color: var(--muted); line-height: 1.6; }
-  .hero-img { width: 100%; border-radius: 14px; aspect-ratio: 16 / 9; object-fit: cover; border: 1px solid var(--border); }
-
-  .share-row { display: flex; gap: 8px; flex-wrap: wrap; }
-
-  .ticker { display: flex; gap: 10px; overflow: hidden; border: 1px solid var(--border); border-radius: 14px; background: #080808; padding: 8px 10px; }
-  .ticker-track { display: flex; gap: 10px; animation: marquee 26s linear infinite; }
-  .chip { padding: 7px 12px; border-radius: 999px; border: 1px solid var(--border); background: #0d0d0d; color: var(--muted); white-space: nowrap; }
-
-  @keyframes marquee { 0% { transform: translateX(0); } 100% { transform: translateX(-50%); } }
-  @media (max-width: 680px) {
-    header { flex-direction: column; align-items: flex-start; }
-  }
-</style>
 <body>
-  <header>
+  <header class="site-header">
     <div class="brand">
       <div class="logo">E</div>
       <div>
         <h1>Emperor News</h1>
-        <p>公開ビュー / LINE公式アカウント向け</p>
+        <p>公開ビュー (旧) もレスポンシブ化</p>
       </div>
     </div>
     <div class="actions">
@@ -71,24 +19,35 @@
     </div>
   </header>
 
-  <main>
+  <main class="container">
     <section class="hero">
-      <div class="mini-pill">公開ページ (旧デザイン)</div>
-      <h2>読者向けのシンプル配信ビュー</h2>
-      <p>管理画面やチャットから登録した記事をそのまま公開。黒基調のモバイル最適化カードで、公式LINEアカウントにもシェアできます。リンクだけで友だち追加と記事閲覧を両立。</p>
-      <div class="cta-row">
-        <a class="pill primary" id="openLine" rel="noreferrer">公式LINEで読む</a>
-        <a class="pill" href="/blog-edit.html" data-requires-auth="true">記事を投稿する</a>
+      <div class="inline-chips">
+        <div class="badge">旧デザイン</div>
+        <div class="badge">スマホ / タブレット / PC</div>
       </div>
-      <div class="cta-row" id="metaInfo"></div>
+      <h2>読者向けのシンプル配信ビュー</h2>
+      <p>以前の公開ページをベースに、余白とカードサイズを調整しました。レスポンシブで見やすく、公式LINEシェアもそのまま利用できます。</p>
+      <div class="actions">
+        <a class="pill primary" id="openLine" rel="noreferrer">公式LINEで読む</a>
+        <a class="pill ghost" href="/blog-edit.html" data-requires-auth="true">記事を投稿する</a>
+      </div>
+      <div class="inline-chips" id="metaInfo"></div>
     </section>
 
-    <div class="ticker" aria-hidden="true">
-      <div class="ticker-track" id="ticker"></div>
-      <div class="ticker-track" id="tickerClone"></div>
-    </div>
+    <section>
+      <div class="ticker" aria-hidden="true">
+        <div class="ticker-track" id="ticker"></div>
+        <div class="ticker-track" id="tickerClone"></div>
+      </div>
+    </section>
 
-    <section class="grid" id="feed"></section>
+    <section>
+      <div class="section-title">
+        <h2>最新カード</h2>
+        <span class="muted">旧レイアウトを再構成</span>
+      </div>
+      <div class="card-grid" id="feed"></div>
+    </section>
   </main>
 
 <script src="/assets/blog-data.js"></script>
@@ -121,9 +80,30 @@
 
   function renderMeta(count) {
     metaInfo.innerHTML = `
-      <span class="mini-pill">公開中 ${count} 件</span>
-      <span class="mini-pill">LINE連携中</span>
+      <span class="badge">公開中 ${count} 件</span>
+      <span class="badge">LINE連携</span>
     `;
+  }
+
+  function renderFeed(list) {
+    feedEl.innerHTML = "";
+    list.forEach((item, idx) => {
+      const articleUrl = `${location.origin}/blog-article.html?id=${idx}`;
+      const shareUrl = buildOfficialLineShare(articleUrl);
+      const card = document.createElement("article");
+      card.className = "card";
+      card.innerHTML = `
+        ${item.image ? `<img class="hero-img" src="${item.image}" alt="${item.title}">` : ""}
+        <h3>${item.title}</h3>
+        <p>${item.body}</p>
+        <div class="meta">${(item.tags || []).map(t => `<span class=\"tag\">#${t}</span>`).join("") || '<span class="tag">#untagged</span>'}</div>
+        <div class="actions">
+          <a class="share line" href="${shareUrl}" target="_blank" rel="noreferrer">公式LINEで共有</a>
+          <a class="share" href="${articleUrl}" target="_blank">記事を開く</a>
+        </div>
+      `;
+      feedEl.appendChild(card);
+    });
   }
 
   function enforceAdminLinks() {
@@ -142,34 +122,11 @@
     });
   }
 
-  function renderFeed(list) {
-    feedEl.innerHTML = "";
-    list.forEach((item, idx) => {
-      const articleUrl = `${location.origin}/blog-article.html?id=${idx}`;
-      const shareUrl = buildOfficialLineShare(articleUrl);
-      const card = document.createElement("article");
-      card.className = "card";
-      card.id = `post-${idx}`;
-      card.innerHTML = `
-        ${item.image ? `<img class="hero-img" src="${item.image}" alt="${item.title}">` : ""}
-        <h3>${item.title}</h3>
-        <p>${item.body}</p>
-        <div class="meta">
-          ${(item.tags || []).map(t => `<span class="tag">#${t}</span>`).join("") || '<span class="tag">#untagged</span>'}
-        </div>
-        <div class="share-row">
-          <a class="share line" href="${shareUrl}" rel="noreferrer">公式LINEで共有</a>
-          <a class="share" href="${articleUrl}">リンクを開く</a>
-        </div>
-      `;
-      feedEl.appendChild(card);
-    });
-  }
-
-  document.addEventListener("DOMContentLoaded", async () => {
+  document.addEventListener("DOMContentLoaded", () => {
     document.getElementById("openLine").href = officialLinePage;
     enforceAdminLinks();
-    const articles = loadArticles();
+    const cached = localStorage.getItem(cacheKey);
+    const articles = cached ? normalizeArticles(JSON.parse(cached)) : BlogData.loadArticles();
     renderFeed(articles);
     renderTicker(articles.flatMap(a => a.tags || []));
     renderMeta(articles.length);

--- a/public/blog.html
+++ b/public/blog.html
@@ -4,75 +4,32 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Emperor News — 公開ビュー</title>
 <link rel="stylesheet" href="/assets/blog-shared.css">
-<style>
-  main { padding: 24px var(--page-inline) 56px; display: grid; gap: 20px; width: 100%; }
-  .hero {
-    background: linear-gradient(135deg, rgba(6, 199, 85, 0.18), rgba(6, 199, 85, 0.05) 32%, rgba(12, 12, 12, 0.9) 100%);
-    border: 1px solid var(--border);
-    border-radius: 26px;
-    padding: 20px;
-    display: grid;
-    gap: 12px;
-    box-shadow: var(--shadow);
-  }
-  .hero h2 { margin: 0; font-size: 22px; }
-  .hero p { margin: 0; color: var(--muted); line-height: 1.6; }
-  .hero .cta-row { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
-  .mini-pill { font-size: 12px; padding: 6px 10px; border-radius: 999px; background: rgba(255,255,255,0.05); border: 1px solid var(--border); color: var(--muted); }
-
-  .scroll-shell { overflow: hidden; border-radius: 24px; border: 1px solid var(--border); background: #0b0b0b; }
-  .scroll-track { display: grid; grid-auto-flow: column; grid-auto-columns: 88%; gap: 12px; overflow-x: auto; padding: 12px; scroll-snap-type: x mandatory; -webkit-overflow-scrolling: touch; }
-  .scroll-track::-webkit-scrollbar { height: 6px; }
-  .scroll-track::-webkit-scrollbar-thumb { background: #1f1f1f; border-radius: 999px; }
-
-  .card {
-    background: var(--panel);
-    border: 1px solid var(--border);
-    border-radius: 20px;
-    padding: 14px;
-    display: grid;
-    gap: 10px;
-    box-shadow: 0 12px 32px rgba(0,0,0,0.3);
-    scroll-snap-align: start;
-  }
-  .card h3 { margin: 0; font-size: 17px; letter-spacing: 0.01em; }
-  .card p { margin: 0; color: var(--muted); line-height: 1.6; }
-  .hero-img { width: 100%; border-radius: 14px; aspect-ratio: 16 / 9; object-fit: cover; border: 1px solid var(--border); }
-
-  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 14px; }
-
-  .share-row { display: flex; gap: 8px; flex-wrap: wrap; }
-
-  .ticker { display: flex; gap: 10px; overflow: hidden; border: 1px solid var(--border); border-radius: 14px; background: #080808; padding: 8px 10px; }
-  .ticker-track { display: flex; gap: 10px; animation: marquee 26s linear infinite; }
-  .chip { padding: 7px 12px; border-radius: 999px; border: 1px solid var(--border); background: #0d0d0d; color: var(--muted); white-space: nowrap; }
-
-  @keyframes marquee { 0% { transform: translateX(0); } 100% { transform: translateX(-50%); } }
-  @media (min-width: 720px) { .scroll-track { grid-auto-columns: 64%; } }
-  @media (min-width: 1024px) { .scroll-track { grid-auto-columns: 42%; } }
-</style>
 <body>
-  <header>
+  <header class="site-header">
     <div class="brand">
       <div class="logo">E</div>
       <div>
         <h1>Emperor News</h1>
-        <p>公開ビュー / LINE公式アカウント向け</p>
+        <p>公開ビュー / LINE共有 / モバイル最適化</p>
       </div>
     </div>
     <div class="actions">
       <a class="pill" href="/">トップ</a>
-      <a class="pill" id="openLine" target="_blank" rel="noreferrer">公式LINEで読む</a>
-      <a class="pill" href="/blog-edit.html" data-requires-auth="true">記事を編集</a>
+      <a class="pill" href="/blog-list.html">一覧ビュー</a>
+      <a class="pill primary" id="openLine" target="_blank" rel="noreferrer">公式LINEで読む</a>
+      <a class="pill ghost" href="/blog-edit.html" data-requires-auth="true">記事を編集</a>
     </div>
   </header>
 
-  <main>
+  <main class="container">
     <section class="hero">
-      <div class="mini-pill">読者向け / /blog</div>
-      <h2>シンプルな公開ブログビュー</h2>
-      <p>チャットや管理画面から追加された記事を自動で配信。黒基調のモバイル最適化カードと公式LINEシェアボタン付きで、友だち追加からの導線も確保します。</p>
-      <div class="cta-row" id="metaInfo"></div>
+      <div class="inline-chips">
+        <div class="badge">読者向け</div>
+        <div class="badge">スマホ / タブレット / PC</div>
+      </div>
+      <h2>カードスタイルのニュースフィード</h2>
+      <p>横スクロールの特集エリアと、タグ付きのカード一覧を刷新しました。スマホでは指でスワイプ、タブレットでは2列寄り、PCでは最大幅1200pxで広々表示します。</p>
+      <div class="inline-chips" id="metaInfo"></div>
     </section>
 
     <section>
@@ -82,11 +39,23 @@
       </div>
     </section>
 
-    <section class="scroll-shell">
-      <div class="scroll-track" id="featureTrack"></div>
+    <section>
+      <div class="section-title">
+        <h2>特集</h2>
+        <span class="muted">スマホは1枚ずつ、PCは複数カードを横並びで</span>
+      </div>
+      <div class="scroll-shell">
+        <div class="scroll-track" id="featureTrack"></div>
+      </div>
     </section>
 
-    <section class="grid" id="feed"></section>
+    <section>
+      <div class="section-title">
+        <h2>最新記事</h2>
+        <span class="muted">LINE共有ボタンとリンク付き</span>
+      </div>
+      <div class="card-grid" id="feed"></div>
+    </section>
   </main>
 
 <script src="/assets/blog-data.js"></script>
@@ -114,8 +83,9 @@
 
   function renderMeta(count) {
     metaInfo.innerHTML = `
-      <span class="mini-pill">公開中 ${count} 件</span>
-      <span class="mini-pill">LINE連携</span>
+      <span class="badge">公開中 ${count} 件</span>
+      <span class="badge">LINE連携</span>
+      <span class="badge">レスポンシブ</span>
     `;
   }
 
@@ -123,7 +93,7 @@
     featureTrack.innerHTML = "";
     list.slice(0, 6).forEach((item, idx) => {
       const card = document.createElement("article");
-      card.className = "card";
+      card.className = "article-card";
       card.innerHTML = `
         <div class="badge">特集 ${idx + 1}</div>
         ${item.image ? `<img class="hero-img" src="${item.image}" alt="${item.title}">` : ""}
@@ -145,12 +115,16 @@
       card.id = `post-${idx}`;
       card.innerHTML = `
         ${item.image ? `<img class="hero-img" src="${item.image}" alt="${item.title}">` : ""}
+        <div class="inline-chips">
+          <span class="badge">#${idx + 1}</span>
+          <span class="badge">レスポンシブカード</span>
+        </div>
         <h3>${item.title}</h3>
         <p>${item.body}</p>
         <div class="meta">${(item.tags || []).map(t => `<span class=\"tag\">#${t}</span>`).join("") || '<span class="tag">#untagged</span>'}</div>
-        <div class="share-row">
+        <div class="actions">
           <a class="share line" href="${shareUrl}" target="_blank" rel="noreferrer">公式LINEで共有</a>
-          <a class="share" href="${articleUrl}" target="_blank">リンクを開く</a>
+          <a class="share" href="${articleUrl}" target="_blank">記事ページを開く</a>
         </div>
       `;
       feedEl.appendChild(card);

--- a/public/index.html
+++ b/public/index.html
@@ -1,18 +1,115 @@
 <!doctype html>
-<html lang="en">
+<html lang="ja">
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Emperor News</title>
-<body style="font:16px/1.6 system-ui;margin:40px;max-width:800px">
-  <h1>Emperor News</h1>
-  <p>Welcome to <strong>emperor.news</strong> — deployed from <em>project-E</em>.</p>
-  <p><a href="/draw.html">🎨 Go to Draw Board</a></p>
-  <p>Status check: <a href="/health.txt">health.txt</a></p>
-<p><a href="/draw.html">Go to Draw Board</a></p>
-<p><a href="/chat-toc.html">Go to Chat TOC Maker</a></p>
-<p><a href="/blog.html">📰 Blog (/blog)</a> — reader-facing feed with LINE sharing</p>
-<p><a href="/blog-list.html">🗂️ Blog List (/blog-list)</a> — responsive list view for phone / tablet / PC</p>
-<p><a href="/admin.html">🛠️ Admin (/admin)</a> — manage posts (create / edit / delete)</p>
-<p><a href="/blog-public.html">📰 Public News Page (legacy)</a> — previous reader view kept for reference</p>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Emperor News | Project-E</title>
+<link rel="stylesheet" href="/assets/base.css">
+<body>
+  <header class="site-header">
+    <div class="brand">
+      <div class="logo">E</div>
+      <div>
+        <h1>Emperor News</h1>
+        <p>スマホ / タブレット / PC 全面刷新</p>
+      </div>
+    </div>
+    <div class="actions">
+      <a class="pill primary" href="/blog.html">公開ビュー</a>
+      <a class="pill" href="/blog-list.html">一覧ビュー</a>
+      <a class="pill ghost" href="/admin.html">管理画面</a>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="hero">
+      <div class="badge">New UI</div>
+      <h2>全ページをレスポンシブで作り直しました</h2>
+      <p>スマホは片手で読みやすく、タブレットは横幅を活かし、PCはサイド情報付きで一覧性を高めました。すべてのページで共通のナビゲーションとダークテーマを採用しています。</p>
+      <div class="actions">
+        <a class="button primary" href="/blog.html">ブログカードビュー</a>
+        <a class="button ghost" href="/blog-list.html">一覧ビュー</a>
+        <a class="button ghost" href="/blog-article.html">単体記事</a>
+      </div>
+    </section>
+
+    <section class="grid-2">
+      <article class="card">
+        <div class="badge">スマホビュー</div>
+        <h3>タップしやすい縦積み</h3>
+        <p>1カラム構成と大きめのタッチターゲットで、iPhoneサイズでも余白にゆとりを持たせています。横スクロールの特集カードも指で操作しやすい幅に調整。</p>
+      </article>
+      <article class="card">
+        <div class="badge">タブレットビュー</div>
+        <h3>横幅を活かした2カラム</h3>
+        <p>768〜1024px帯では、サムネイルと本文を横並びにし、サイドメタ情報も表示。Splitレイアウトで情報量と読みやすさを両立しています。</p>
+      </article>
+      <article class="card">
+        <div class="badge">PCビュー</div>
+        <h3>最大幅1200pxのワイドUI</h3>
+        <p>記事一覧＋サイドバー、エディタとプレビューなど、PCでの操作性を優先した配置に。固定ヘッダーと段階的な余白で視線移動を最小化します。</p>
+      </article>
+      <article class="card">
+        <div class="badge">管理・ツール</div>
+        <h3>描画・チャット TOC も統一デザイン</h3>
+        <p>管理ログイン、ブログ編集、描画ツール、チャットTOCメーカーも新しいベースレイアウトを適用。すべての機能が同じUI部品でまとまりました。</p>
+      </article>
+    </section>
+
+    <section class="section">
+      <div class="section-title">
+        <h2>ページリンク</h2>
+        <span class="muted">すべてレスポンシブ対応</span>
+      </div>
+      <div class="card-grid">
+        <article class="card">
+          <h3>🎨 Draw Board</h3>
+          <p>新しいダークテーマとレスポンシブボタンで描画ツールも刷新。指でもマウスでも快適です。</p>
+          <a class="button primary" href="/draw.html">開く</a>
+        </article>
+        <article class="card">
+          <h3>🗂️ 管理ビュー</h3>
+          <p>ログイン後のナビゲーション、認証エラー表示を更新し、リダイレクト導線も整理しました。</p>
+          <a class="button ghost" href="/admin.html">開く</a>
+        </article>
+        <article class="card">
+          <h3>📰 Blog (カード)</h3>
+          <p>LINE共有付きのカード一覧。横スクロール特集とチップ型ティッカーを搭載。</p>
+          <a class="button ghost" href="/blog.html">開く</a>
+        </article>
+        <article class="card">
+          <h3>📑 Blog (一覧)</h3>
+          <p>スマホ1カラム、タブレット2カラム、PC2カラム＋サイドバー。新しい統計ウィジェット付き。</p>
+          <a class="button ghost" href="/blog-list.html">開く</a>
+        </article>
+        <article class="card">
+          <h3>✏️ Blog 編集</h3>
+          <p>フォームとリストを整理し、編集状態やタグ表示を強調。保存後のフィードバックも改善。</p>
+          <a class="button ghost" href="/blog-edit.html">開く</a>
+        </article>
+        <article class="card">
+          <h3>📱 旧公開ビュー</h3>
+          <p>レガシー公開ページも新しいスタイルで表示。ブログ記事との互換性を維持しています。</p>
+          <a class="button ghost" href="/blog-public.html">開く</a>
+        </article>
+        <article class="card">
+          <h3>💬 Chat TOC Maker</h3>
+          <p>チャットの目次生成ツールを新レイアウトに刷新。レスポンシブでシンプルな入力に。</p>
+          <a class="button ghost" href="/chat-toc.html">開く</a>
+        </article>
+        <article class="card">
+          <h3>📰 記事ビュー</h3>
+          <p>個別記事ページは本文とタグ、共有ボタンを再配置。読みやすさを優先した新デザインです。</p>
+          <a class="button ghost" href="/blog-article.html">開く</a>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="section-title">
+      <span>Project-E / Emperor News</span>
+      <span class="tiny">スマホ・タブレット・PCで同じ体験を届けます。</span>
+    </div>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild public landing, blog views, and admin flows with unified responsive design
- add shared base stylesheet to standardize typography, layout, and device breakpoints
- refresh blog article, edit, and legacy views with updated cards, meta chips, and LINE sharing

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69426ee96c008321b74fea937d5029e9)