### PR TITLE
Convert blog list to card layout

### DIFF
--- a/public/assets/base.css
+++ b/public/assets/base.css
@@ -325,20 +325,49 @@ textarea { resize: vertical; min-height: 140px; }
   flex-wrap: wrap;
 }
 
-.list { display: grid; }
+  .list { display: grid; }
 
-.list-card {
-  display: grid;
-  gap: 12px;
-  padding: 14px;
-  border-bottom: 1px solid var(--border);
-  transition: background 160ms ease, transform 160ms ease;
-}
+  .list-card {
+    display: grid;
+    gap: 12px;
+    padding: 14px;
+    border-bottom: 1px solid var(--border);
+    transition: background 160ms ease, transform 160ms ease;
+  }
 
-.list-card:last-child { border-bottom: none; }
-.list-card:hover { background: rgba(255,255,255,0.03); transform: translateY(-2px); }
+  .list-card:last-child { border-bottom: none; }
+  .list-card:hover { background: rgba(255,255,255,0.03); transform: translateY(-2px); }
 
-.latest-list .list { gap: 0; }
+  .list.card-layout {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 14px;
+    padding: 16px;
+    background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));
+  }
+
+  .list.card-layout .list-card {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: linear-gradient(145deg, rgba(255,255,255,0.02), rgba(0,0,0,0.35));
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.38);
+    border-bottom: none;
+    transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease;
+  }
+
+  .list.card-layout .list-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 22px 54px rgba(0, 0, 0, 0.48);
+    background: linear-gradient(145deg, rgba(255,255,255,0.04), rgba(0,0,0,0.42));
+  }
+
+  .list.card-layout .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .latest-list .list { gap: 0; }
 
 .latest-card h3 { margin: 0; font-size: 17px; letter-spacing: 0.01em; }
 .latest-card p { margin: 0; color: var(--muted); line-height: 1.6; }

--- a/public/blog-list.html
+++ b/public/blog-list.html
@@ -63,7 +63,7 @@
           </div>
           <div class="badge" id="countBadge"></div>
         </div>
-        <div class="list" id="list"></div>
+        <div class="list card-layout" id="list"></div>
       </div>
 
       <aside class="stack" aria-label="サイド情報">
@@ -142,7 +142,6 @@
             </div>
             <div class="actions">
               <a class="share line" href="${shareUrl}" target="_blank" rel="noreferrer">LINEで共有</a>
-              <a class="share" href="${articleUrl}" target="_blank">記事ページ</a>
             </div>
           </div>
         `;


### PR DESCRIPTION
## Summary
- restyle the blog list view to show articles in a responsive card grid
- remove the article page link so each item only offers LINE sharing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694283ec24708321bb4a641d4cd865d1)