### PR TITLE
Add tag archive navigation and clickable tags

### DIFF
--- a/public/archive-month.html
+++ b/public/archive-month.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="ja">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>月別ページ | Emperor News</title>
+<link rel="stylesheet" href="/assets/blog-shared.css">
+<body>
+  <header class="site-header">
+    <div class="brand">
+      <div class="logo">E</div>
+      <div>
+        <h1>月別アーカイブ</h1>
+        <p>タグページから遷移できる月別まとめ</p>
+      </div>
+    </div>
+    <div class="actions">
+      <a class="pill" href="/tag.html">タグまとめ</a>
+      <a class="pill ghost" href="/">トップ</a>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="panel">
+      <div class="section-title">
+        <h3>月別リンク</h3>
+        <span class="tiny">最新12か月のプレースホルダー</span>
+      </div>
+      <div class="list card-layout" id="monthList"></div>
+    </section>
+  </main>
+
+  <script>
+    const monthList = document.getElementById("monthList");
+    const now = new Date();
+
+    function formatLabel(date) {
+      const year = date.getFullYear();
+      const month = date.getMonth() + 1;
+      return `${year}年${month.toString().padStart(2, "0")}月`;
+    }
+
+    function renderMonths() {
+      for (let i = 0; i < 12; i += 1) {
+        const next = new Date(now.getFullYear(), now.getMonth() - i, 1);
+        const card = document.createElement("article");
+        card.className = "card";
+        card.innerHTML = `
+          <h3>${formatLabel(next)}</h3>
+          <p class="muted">この月のアーカイブページのリンクを配置予定。</p>
+        `;
+        monthList.appendChild(card);
+      }
+    }
+
+    document.addEventListener("DOMContentLoaded", renderMonths);
+  </script>
+</body>
+</html>

--- a/public/archive-year.html
+++ b/public/archive-year.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="ja">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>年別ページ | Emperor News</title>
+<link rel="stylesheet" href="/assets/blog-shared.css">
+<body>
+  <header class="site-header">
+    <div class="brand">
+      <div class="logo">E</div>
+      <div>
+        <h1>年別アーカイブ</h1>
+        <p>タグページの下からアクセスする年別まとめ</p>
+      </div>
+    </div>
+    <div class="actions">
+      <a class="pill" href="/tag.html">タグまとめ</a>
+      <a class="pill ghost" href="/">トップ</a>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="panel">
+      <div class="section-title">
+        <h3>年別リンク</h3>
+        <span class="tiny">直近5年分のプレースホルダー</span>
+      </div>
+      <div class="list card-layout" id="yearList"></div>
+    </section>
+  </main>
+
+  <script>
+    const yearList = document.getElementById("yearList");
+    const now = new Date();
+
+    function renderYears() {
+      for (let i = 0; i < 5; i += 1) {
+        const year = now.getFullYear() - i;
+        const card = document.createElement("article");
+        card.className = "card";
+        card.innerHTML = `
+          <h3>${year}年</h3>
+          <p class="muted">この年のアーカイブページのリンクを配置予定。</p>
+        `;
+        yearList.appendChild(card);
+      }
+    }
+
+    document.addEventListener("DOMContentLoaded", renderYears);
+  </script>
+</body>
+</html>

--- a/public/assets/base.css
+++ b/public/assets/base.css
@@ -285,7 +285,18 @@ textarea { resize: vertical; min-height: 140px; }
 
 .tag-row { display: flex; gap: 8px; flex-wrap: wrap; }
 
-.tag { padding: 6px 10px; border-radius: 999px; border: 1px solid var(--border); background: #0c0c0c; font-size: 12px; }
+.tag {
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: #0c0c0c;
+  font-size: 12px;
+  color: var(--text);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
 
 .tablet-hint, .pc-hint, .mobile-hint {
   font-size: 13px;

--- a/public/blog-article.html
+++ b/public/blog-article.html
@@ -70,7 +70,8 @@
     meta.innerHTML = `
       <span class="badge">ID ${articleIdx}</span>
       <span class="badge">レスポンシブ本文</span>
-      ${(article.tags || []).map(tag => `<span class=\"badge\">#${tag}</span>`).join("")}
+      ${(article.tags || []).map(tag => `<a class=\"tag\" href=\"/tag.html?tag=${encodeURIComponent(tag)}\">#${tag}</a>`).join(""
+      )}
     `;
 
     if (article.image) {

--- a/public/blog-edit.html
+++ b/public/blog-edit.html
@@ -245,7 +245,7 @@
             </div>
             <h3 style="margin:0;">${article.title || "無題の記事"}</h3>
             <p class="muted">${article.body?.slice(0, 80) || "本文がありません"}</p>
-            <div class="tag-row">${(article.tags || []).map(tag => `<span class="tag">#${tag}</span>`).join("") || '<span class="tag">#untagged</span>'}</div>
+            <div class="tag-row">${(article.tags || []).map(tag => `<a class="tag" href="/tag.html?tag=${encodeURIComponent(tag)}">#${tag}</a>`).join("") || '<span class="tag">#untagged</span>'}</div>
           </div>
           <div class="stack" style="gap:6px; align-items:flex-end;">
             <button class="secondary" data-action="edit" data-idx="${idx}">編集</button>

--- a/public/blog-list.html
+++ b/public/blog-list.html
@@ -74,14 +74,6 @@
       <aside class="stack" aria-label="サイド情報">
         <div class="panel">
           <div class="section-title" style="gap:6px;">
-            <h3>ビューのステータス</h3>
-            <span class="tiny">タブレット以上で右カラムに固定</span>
-          </div>
-          <div class="card-grid" id="stats"></div>
-        </div>
-
-        <div class="panel">
-          <div class="section-title" style="gap:6px;">
             <h3>タグクラウド</h3>
             <span class="tiny">使用頻度順に表示</span>
           </div>
@@ -105,7 +97,6 @@
     const officialLinePage = "https://page.line.me/projecte_official";
     const adminSessionKey = "emperor_admin_token";
     const listEl = document.getElementById("list");
-    const statsEl = document.getElementById("stats");
     const tagCloud = document.getElementById("tagCloud");
     const metaInfo = document.getElementById("metaInfo");
     const countBadge = document.getElementById("countBadge");
@@ -157,7 +148,7 @@
             <h3 style="margin:0; font-size:18px; letter-spacing:0.01em;">${item.title}</h3>
             <p class="muted">${item.body}</p>
             <div class="meta">
-              ${(item.tags || []).map(t => `<span class="tag">#${t}</span>`).join("") || '<span class="tag">#untagged</span>'}
+              ${(item.tags || []).map(t => `<a class="tag" href="/tag.html?tag=${encodeURIComponent(t)}">#${t}</a>`).join("") || '<span class="tag">#untagged</span>'}
             </div>
             <div class="actions">
               <a class="share line" href="${shareUrl}" target="_blank" rel="noreferrer">LINEで共有</a>
@@ -202,21 +193,6 @@
       `;
     }
 
-    function renderStats(list) {
-      statsEl.innerHTML = "";
-      const statItems = [
-        { label: "記事数", value: `${list.length} 件` },
-        { label: "スマホ/タブレット対応", value: "横2列⇔縦1列 自動切替" },
-        { label: "LINE共有", value: "公式アカウントへ誘導" },
-      ];
-      statItems.forEach((item) => {
-        const box = document.createElement("div");
-        box.className = "card";
-        box.innerHTML = `<h3>${item.label}</h3><p class="muted">${item.value}</p>`;
-        statsEl.appendChild(box);
-      });
-    }
-
     function renderTags(list) {
       tagCloud.innerHTML = "";
       const counts = new Map();
@@ -229,8 +205,9 @@
         return;
       }
       entries.forEach(([tag, count]) => {
-        const chip = document.createElement("span");
+        const chip = document.createElement("a");
         chip.className = "tag";
+        chip.href = `/tag.html?tag=${encodeURIComponent(tag)}`;
         chip.textContent = `#${tag} (${count})`;
         tagCloud.appendChild(chip);
       });
@@ -264,7 +241,7 @@
             <h3 style="margin:0; font-size:18px; letter-spacing:0.01em;">${item.title}</h3>
             <p class="muted">${item.body}</p>
             <div class="meta">
-              ${(item.tags || []).map(t => `<span class="tag">#${t}</span>`).join("") || '<span class="tag">#untagged</span>'}
+              ${(item.tags || []).map(t => `<a class="tag" href="/tag.html?tag=${encodeURIComponent(t)}">#${t}</a>`).join("") || '<span class="tag">#untagged</span>'}
             </div>
             <div class="actions">
               <a class="share" href="${articleUrl}" target="_blank">記事を開く</a>
@@ -283,7 +260,6 @@
       const settings = BlogData.loadSettings();
       renderFeatured(settings, articles);
       renderList(articles);
-      renderStats(articles);
       renderTags(articles);
       renderMeta(articles.length);
       renderPinned(articles, settings);

--- a/public/tag.html
+++ b/public/tag.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="ja">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>タグまとめ | Emperor News</title>
+<link rel="stylesheet" href="/assets/blog-shared.css">
+<body>
+  <header class="site-header">
+    <div class="brand">
+      <div class="logo">E</div>
+      <div>
+        <h1>タグまとめ</h1>
+        <p>タップしたタグの記事を絞り込み</p>
+      </div>
+    </div>
+    <div class="actions">
+      <a class="pill" href="/blog-list.html">一覧へ</a>
+      <a class="pill ghost" href="/">トップ</a>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="hero">
+      <div class="inline-chips" id="tagMeta"></div>
+      <h2 id="tagTitle">タグ一覧</h2>
+      <p class="muted" id="tagLead">指定されたタグの記事を読み込み中です。</p>
+    </section>
+
+    <section class="panel">
+      <div class="list card-layout" id="tagList"></div>
+    </section>
+
+    <section class="panel" id="archiveLinks">
+      <div class="section-title">
+        <h3>アーカイブ</h3>
+        <span class="tiny">タグページの下に月別・年別ページへのリンク</span>
+      </div>
+      <div class="actions">
+        <a class="pill" href="/archive-month.html">月別ページ</a>
+        <a class="pill" href="/archive-year.html">年別ページ</a>
+      </div>
+    </section>
+  </main>
+
+  <script src="/assets/lightbox.js"></script>
+  <script src="/assets/blog-data.js"></script>
+  <script>
+    const params = new URLSearchParams(location.search);
+    const rawTag = params.get("tag") || "";
+    const activeTag = rawTag.trim();
+    const tagMeta = document.getElementById("tagMeta");
+    const tagTitle = document.getElementById("tagTitle");
+    const tagLead = document.getElementById("tagLead");
+    const tagList = document.getElementById("tagList");
+
+    function renderList(tag, list) {
+      tagList.innerHTML = "";
+      if (!tag) {
+        tagTitle.textContent = "タグが指定されていません";
+        tagLead.textContent = "一覧ページからタグをタップすると記事を絞り込めます。";
+        tagList.innerHTML = '<p class="muted">タグを選択して再度アクセスしてください。</p>';
+        return;
+      }
+
+      const filtered = list
+        .map((item, idx) => ({ item, idx }))
+        .filter(({ item }) => (item.tags || []).includes(tag));
+      tagTitle.textContent = `#${tag} の記事`;
+      tagLead.textContent = filtered.length
+        ? "タップしたタグに関連する記事をまとめています。"
+        : "まだこのタグの記事はありません。";
+      tagMeta.innerHTML = `
+        <span class="badge">${filtered.length} 件</span>
+        <span class="badge">タグまとめ</span>
+      `;
+
+      if (!filtered.length) {
+        tagList.innerHTML = '<p class="muted">タグを付けた記事を追加するとここに表示されます。</p>';
+        return;
+      }
+
+      filtered.forEach(({ item, idx }) => {
+        const card = document.createElement("article");
+        card.className = "list-card";
+        const articleUrl = `${location.origin}/blog-article.html?id=${idx}`;
+        card.innerHTML = `
+          ${item.image ? `<img class="thumb" src="${item.image}" alt="${item.title}">` : '<div class="thumb fallback">NO IMAGE</div>'}
+          <div class="stack" style="gap:12px;">
+            <div class="inline-chips">
+              <span class="badge">#${idx + 1}</span>
+              <span class="badge">${(item.tags || []).length} タグ</span>
+            </div>
+            <h3 style="margin:0; font-size:18px; letter-spacing:0.01em;">${item.title}</h3>
+            <p class="muted">${item.body}</p>
+            <div class="meta">
+              ${(item.tags || []).map(t => `<a class="tag" href="/tag.html?tag=${encodeURIComponent(t)}">#${t}</a>`).join("") || '<span class="tag">#untagged</span>'}
+            </div>
+            <div class="actions">
+              <a class="share" href="${articleUrl}" target="_blank">記事を開く</a>
+            </div>
+          </div>
+        `;
+        tagList.appendChild(card);
+      });
+      Lightbox.enhanceImages(tagList);
+    }
+
+    document.addEventListener("DOMContentLoaded", () => {
+      const articles = BlogData.loadArticles();
+      renderList(activeTag, articles);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove the view status panel from the list page and make visible tags link to a tag summary
- add a tag summary page plus month/year archive placeholders linked from each tag view
- adjust tag styling so linkable chips stay consistent across list, article, and editor views

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69428cb2ac30832192e9537fc1eaff23)