### PR TITLE
Add admin-selectable hero article

### DIFF
--- a/public/assets/blog-data.js
+++ b/public/assets/blog-data.js
@@ -40,13 +40,16 @@
   function normalizeSettings(raw) {
     const articles = loadArticles();
     const limit = articles.length;
+    const heroId = Number.isInteger(raw?.heroId) && raw.heroId >= 0 && raw.heroId < limit
+      ? raw.heroId
+      : (limit ? 0 : null);
     const featuredId = Number.isInteger(raw?.featuredId) && raw.featuredId >= 0 && raw.featuredId < limit
       ? raw.featuredId
       : (limit ? 0 : null);
     const footerIds = Array.isArray(raw?.footerIds)
       ? [...new Set(raw.footerIds.filter((idx) => Number.isInteger(idx) && idx >= 0 && idx < limit))]
       : [];
-    return { featuredId, footerIds };
+    return { heroId, featuredId, footerIds };
   }
 
   function loadSettings() {
@@ -97,6 +100,13 @@
     return { article: list[safeIdx], list, idx: safeIdx };
   }
 
+  function getHeroArticle() {
+    const settings = loadSettings();
+    if (!Number.isInteger(settings.heroId)) return { article: null, idx: null, settings };
+    const { article, idx } = findArticle(settings.heroId);
+    return { article, idx, settings };
+  }
+
   function getFeaturedArticle() {
     const settings = loadSettings();
     if (!Number.isInteger(settings.featuredId)) return { article: null, idx: null, settings };
@@ -129,6 +139,7 @@
     upsertArticle,
     deleteArticle,
     findArticle,
+    getHeroArticle,
     getFeaturedArticle,
     getFooterArticles,
     buildOfficialLineShare,

--- a/public/blog-edit.html
+++ b/public/blog-edit.html
@@ -51,6 +51,10 @@
       </div>
       <form class="stack" id="settingsForm">
         <div class="form-row">
+          <label class="tiny" for="heroSelect">トップヒーロー（トップページの強調枠）</label>
+          <select id="heroSelect"></select>
+        </div>
+        <div class="form-row">
           <label class="tiny" for="featuredSelect">注目記事（一覧の一番上）</label>
           <select id="featuredSelect"></select>
         </div>
@@ -126,6 +130,7 @@
   const imageStatus = document.getElementById("imageStatus");
   const clearImageBtn = document.getElementById("clearImage");
   const settingsForm = document.getElementById("settingsForm");
+  const heroSelect = document.getElementById("heroSelect");
   const featuredSelect = document.getElementById("featuredSelect");
   const pinnedChoices = document.getElementById("pinnedChoices");
   const settingsStatus = document.getElementById("settingsStatus");
@@ -184,15 +189,22 @@
   function renderSettingsForm() {
     const articles = BlogData.loadArticles();
     const settings = BlogData.saveSettings(BlogData.loadSettings());
+    heroSelect.innerHTML = "";
     featuredSelect.innerHTML = "";
     pinnedChoices.innerHTML = "";
 
     if (!articles.length) {
+      heroSelect.innerHTML = '<option value="">記事がありません</option>';
       featuredSelect.innerHTML = '<option value="">記事がありません</option>';
       pinnedChoices.innerHTML = '<span class="tiny">記事追加後に設定できます。</span>';
       settingsStatus.textContent = "記事を追加すると設定できます。";
       return;
     }
+
+    const heroFallbackOpt = document.createElement("option");
+    heroFallbackOpt.value = "";
+    heroFallbackOpt.textContent = "未指定 (先頭の記事を表示)";
+    heroSelect.appendChild(heroFallbackOpt);
 
     const fallbackOpt = document.createElement("option");
     fallbackOpt.value = "";
@@ -200,6 +212,12 @@
     featuredSelect.appendChild(fallbackOpt);
 
     articles.forEach((article, idx) => {
+      const heroOption = document.createElement("option");
+      heroOption.value = String(idx);
+      heroOption.textContent = `ID ${idx}: ${article.title || "無題"}`;
+      if (settings.heroId === idx) heroOption.selected = true;
+      heroSelect.appendChild(heroOption);
+
       const opt = document.createElement("option");
       opt.value = String(idx);
       opt.textContent = `ID ${idx}: ${article.title || "無題"}`;
@@ -222,7 +240,7 @@
       pinnedChoices.appendChild(row);
     });
 
-    settingsStatus.textContent = `注目: ${Number.isInteger(settings.featuredId) ? `ID ${settings.featuredId}` : "未指定"} / 固定 ${settings.footerIds.length} 件`;
+    settingsStatus.textContent = `ヒーロー: ${Number.isInteger(settings.heroId) ? `ID ${settings.heroId}` : "未指定"} / 注目: ${Number.isInteger(settings.featuredId) ? `ID ${settings.featuredId}` : "未指定"} / 固定 ${settings.footerIds.length} 件`;
   }
 
   function renderList() {
@@ -308,12 +326,13 @@
 
   function handleSettingsSave(event) {
     event.preventDefault();
+    const heroId = heroSelect.value === "" ? null : parseInt(heroSelect.value, 10);
     const featuredId = featuredSelect.value === "" ? null : parseInt(featuredSelect.value, 10);
     const footerIds = Array.from(pinnedChoices.querySelectorAll('input[type="checkbox"]:checked'))
       .map((input) => parseInt(input.value, 10))
       .filter(Number.isInteger);
-    const normalized = BlogData.saveSettings({ featuredId, footerIds });
-    settingsStatus.textContent = `注目: ${Number.isInteger(normalized.featuredId) ? `ID ${normalized.featuredId}` : "未指定"} / 固定 ${normalized.footerIds.length} 件 保存しました`;
+    const normalized = BlogData.saveSettings({ heroId, featuredId, footerIds });
+    settingsStatus.textContent = `ヒーロー: ${Number.isInteger(normalized.heroId) ? `ID ${normalized.heroId}` : "未指定"} / 注目: ${Number.isInteger(normalized.featuredId) ? `ID ${normalized.featuredId}` : "未指定"} / 固定 ${normalized.footerIds.length} 件 保存しました`;
   }
 
   document.addEventListener("DOMContentLoaded", () => {

--- a/public/index.html
+++ b/public/index.html
@@ -21,10 +21,14 @@
 
   <main class="container">
     <section class="hero">
-      <div class="badge">New UI</div>
-      <h2>全ページをレスポンシブで作り直しました</h2>
-      <p>スマホは片手で読みやすく、タブレットは横幅を活かし、PCはサイド情報付きで一覧性を高めました。すべてのページで共通のナビゲーションとダークテーマを採用しています。</p>
-      <div class="actions">
+      <div class="inline-chips">
+        <div class="badge" id="heroBadge">New UI</div>
+        <div class="badge" id="heroMeta">レスポンシブ更新</div>
+      </div>
+      <h2 id="heroTitle">全ページをレスポンシブで作り直しました</h2>
+      <p id="heroBody">スマホは片手で読みやすく、タブレットは横幅を活かし、PCはサイド情報付きで一覧性を高めました。すべてのページで共通のナビゲーションとダークテーマを採用しています。</p>
+      <div class="tag-row" id="heroTags"></div>
+      <div class="actions" id="heroActions">
         <a class="button primary" href="/blog-list.html">ブログ一覧ビュー</a>
         <a class="button ghost" href="/blog-article.html">単体記事</a>
         <a class="button ghost" href="/blog-edit.html">記事編集</a>
@@ -206,5 +210,73 @@
     </div>
   </footer>
   <script src="/assets/lightbox.js"></script>
+  <script src="/assets/blog-data.js"></script>
+  <script>
+    const heroTitle = document.getElementById("heroTitle");
+    const heroBody = document.getElementById("heroBody");
+    const heroTags = document.getElementById("heroTags");
+    const heroActions = document.getElementById("heroActions");
+    const heroBadge = document.getElementById("heroBadge");
+    const heroMeta = document.getElementById("heroMeta");
+
+    const heroFallback = {
+      title: "全ページをレスポンシブで作り直しました",
+      body: "スマホは片手で読みやすく、タブレットは横幅を活かし、PCはサイド情報付きで一覧性を高めました。すべてのページで共通のナビゲーションとダークテーマを採用しています。",
+      tags: ["スマホ対応", "タブレット", "PC"]
+    };
+
+    function renderHeroFromArticle() {
+      const { article, idx } = BlogData.getHeroArticle();
+      const articles = BlogData.loadArticles();
+      heroTags.innerHTML = "";
+      heroActions.innerHTML = "";
+
+      if (!articles.length || !article) {
+        heroBadge.textContent = "New UI";
+        heroMeta.textContent = "レスポンシブ更新";
+        heroTitle.textContent = heroFallback.title;
+        heroBody.textContent = heroFallback.body;
+        heroFallback.tags.forEach((tag) => {
+          const chip = document.createElement("span");
+          chip.className = "badge";
+          chip.textContent = tag;
+          heroTags.appendChild(chip);
+        });
+        heroActions.innerHTML = `
+          <a class="button primary" href="/blog-list.html">ブログ一覧ビュー</a>
+          <a class="button ghost" href="/blog-article.html">単体記事</a>
+          <a class="button ghost" href="/blog-edit.html">記事編集</a>
+        `;
+        return;
+      }
+
+      heroBadge.textContent = "トップおすすめ";
+      heroMeta.textContent = `ID ${idx}`;
+      heroTitle.textContent = article.title || "無題の記事";
+      heroBody.textContent = article.body || "本文がありません";
+
+      if (article.tags?.length) {
+        article.tags.forEach((tag) => {
+          const link = document.createElement("a");
+          link.className = "tag";
+          link.href = `/tag.html?tag=${encodeURIComponent(tag)}`;
+          link.textContent = `#${tag}`;
+          heroTags.appendChild(link);
+        });
+      } else {
+        heroTags.innerHTML = '<span class="badge">#untagged</span>';
+      }
+
+      const articleUrl = `${location.origin}/blog-article.html?id=${idx}`;
+      const shareUrl = BlogData.buildOfficialLineShare(articleUrl);
+      heroActions.innerHTML = `
+        <a class="button primary" href="/blog-list.html">ブログ一覧ビュー</a>
+        <a class="button ghost" href="${articleUrl}">この記事を読む</a>
+        <a class="button ghost" href="${shareUrl}" target="_blank" rel="noreferrer">LINEで共有</a>
+      `;
+    }
+
+    document.addEventListener("DOMContentLoaded", renderHeroFromArticle);
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a homepage hero article setting to stored blog data
- expose hero selection controls in the admin settings form
- render the homepage hero using the selected article with tags and share links

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69428e21bae48321b9239d95f8a4dd81)