### PR TITLE
Add automatic image resizing and editable copy settings

### DIFF
--- a/public/assets/blog-data.js
+++ b/public/assets/blog-data.js
@@ -1,6 +1,7 @@
 (() => {
   const storageKey = "emperor_articles";
   const settingsKey = "emperor_article_settings";
+  const copyKey = "emperor_article_copy";
   const officialLineAccountId = "@projecte_official";
   const baseArticles = [
     {
@@ -74,6 +75,44 @@
     return normalized;
   }
 
+  const defaultCopy = {
+    heroTitle: "幅に合わせて表情を変える一覧ビュー",
+    heroBody: "スマホでは縦にカードを並べ、タブレットはサムネイル横並び、PCではサイドバー付きの2カラムで統計とタグクラウドを固定。見やすさを保ちながら情報量を増やしました。",
+    mobileTitle: "スマホビュー",
+    mobileBody: "1カラムでサムネイルを上、本文とタグを下に配置。タップしやすい余白を確保しました。",
+    tabletTitle: "タブレットビュー",
+    tabletBody: "サムネイル横並び＋行間拡大。768px以上で自動適用されます。",
+    pcTitle: "PCビュー",
+    pcBody: "最大幅1200pxで2カラム＋サイドバーを固定。タグクラウドと統計を右側に表示します。",
+    shareTitle: "共有と導線",
+    shareBody: "各記事にLINE共有と記事リンクを配置。管理者リンクは認証が必要な場合のみ遷移します。",
+    listTitle: "最新の投稿",
+    listSubtitle: "ローカル保存された記事を時系列順に一覧表示します。",
+    pinnedTitle: "固定記事",
+    pinnedSubtitle: "管理ページで選択された記事を表示",
+    tagTitle: "タグクラウド",
+    tagSubtitle: "使用頻度順に表示",
+  };
+
+  function loadCopy() {
+    const saved = localStorage.getItem(copyKey);
+    if (!saved) return { ...defaultCopy };
+    try {
+      const parsed = JSON.parse(saved);
+      return { ...defaultCopy, ...(parsed && typeof parsed === "object" ? parsed : {}) };
+    } catch (err) {
+      console.warn("Failed to parse article copy", err);
+      return { ...defaultCopy };
+    }
+  }
+
+  function saveCopy(next) {
+    const copy = next && typeof next === "object" ? next : {};
+    const normalized = { ...defaultCopy, ...copy };
+    localStorage.setItem(copyKey, JSON.stringify(normalized));
+    return normalized;
+  }
+
   function upsertArticle(article, idx) {
     const list = loadArticles();
     if (Number.isInteger(idx) && idx >= 0 && idx < list.length) {
@@ -130,12 +169,16 @@
   window.BlogData = {
     storageKey,
     settingsKey,
+    copyKey,
     officialLineAccountId,
     baseArticles,
+    defaultCopy,
     loadArticles,
     saveArticles,
     loadSettings,
     saveSettings,
+    loadCopy,
+    saveCopy,
     upsertArticle,
     deleteArticle,
     findArticle,

--- a/public/blog-edit.html
+++ b/public/blog-edit.html
@@ -70,6 +70,85 @@
     </section>
 
     <section class="panel stack">
+      <div class="section-title">
+        <h3>文言設定</h3>
+        <span class="tiny">一覧ページの各項目テキストを変更</span>
+      </div>
+      <form class="stack" id="copyForm">
+        <div class="grid-2" style="gap:12px;">
+          <div class="form-row">
+            <label class="tiny" for="heroTitle">ヒーロータイトル</label>
+            <input id="heroTitle" name="heroTitle" required>
+          </div>
+          <div class="form-row">
+            <label class="tiny" for="heroBody">ヒーロー本文</label>
+            <textarea id="heroBody" name="heroBody" required></textarea>
+          </div>
+          <div class="form-row">
+            <label class="tiny" for="mobileTitle">スマホ見出し</label>
+            <input id="mobileTitle" name="mobileTitle" required>
+          </div>
+          <div class="form-row">
+            <label class="tiny" for="mobileBody">スマホ本文</label>
+            <textarea id="mobileBody" name="mobileBody" required></textarea>
+          </div>
+          <div class="form-row">
+            <label class="tiny" for="tabletTitle">タブレット見出し</label>
+            <input id="tabletTitle" name="tabletTitle" required>
+          </div>
+          <div class="form-row">
+            <label class="tiny" for="tabletBody">タブレット本文</label>
+            <textarea id="tabletBody" name="tabletBody" required></textarea>
+          </div>
+          <div class="form-row">
+            <label class="tiny" for="pcTitle">PC見出し</label>
+            <input id="pcTitle" name="pcTitle" required>
+          </div>
+          <div class="form-row">
+            <label class="tiny" for="pcBody">PC本文</label>
+            <textarea id="pcBody" name="pcBody" required></textarea>
+          </div>
+          <div class="form-row">
+            <label class="tiny" for="shareTitle">共有セクション見出し</label>
+            <input id="shareTitle" name="shareTitle" required>
+          </div>
+          <div class="form-row">
+            <label class="tiny" for="shareBody">共有セクション本文</label>
+            <textarea id="shareBody" name="shareBody" required></textarea>
+          </div>
+          <div class="form-row">
+            <label class="tiny" for="listTitle">一覧セクション見出し</label>
+            <input id="listTitle" name="listTitle" required>
+          </div>
+          <div class="form-row">
+            <label class="tiny" for="listSubtitle">一覧セクション補足</label>
+            <textarea id="listSubtitle" name="listSubtitle" required></textarea>
+          </div>
+          <div class="form-row">
+            <label class="tiny" for="pinnedTitle">固定セクション見出し</label>
+            <input id="pinnedTitle" name="pinnedTitle" required>
+          </div>
+          <div class="form-row">
+            <label class="tiny" for="pinnedSubtitle">固定セクション補足</label>
+            <textarea id="pinnedSubtitle" name="pinnedSubtitle" required></textarea>
+          </div>
+          <div class="form-row">
+            <label class="tiny" for="tagTitle">タグクラウド見出し</label>
+            <input id="tagTitle" name="tagTitle" required>
+          </div>
+          <div class="form-row">
+            <label class="tiny" for="tagSubtitle">タグクラウド補足</label>
+            <textarea id="tagSubtitle" name="tagSubtitle" required></textarea>
+          </div>
+        </div>
+        <div class="actions" style="justify-content: space-between; align-items: center; flex-wrap: wrap;">
+          <button class="primary" type="submit">文言を保存</button>
+          <span class="tiny" id="copyStatus">一覧ページに即時反映されます。</span>
+        </div>
+      </form>
+    </section>
+
+    <section class="panel stack">
       <form class="stack" id="editorForm">
         <div class="form-row">
           <label for="title" class="tiny">タイトル</label>
@@ -134,6 +213,8 @@
   const featuredSelect = document.getElementById("featuredSelect");
   const pinnedChoices = document.getElementById("pinnedChoices");
   const settingsStatus = document.getElementById("settingsStatus");
+  const copyForm = document.getElementById("copyForm");
+  const copyStatus = document.getElementById("copyStatus");
   let editingIdx = null;
   let imageData = "";
 
@@ -162,7 +243,35 @@
     imageStatus.textContent = "保存後、公開ビューでタップ拡大できます。";
   }
 
-  function handleFileSelect(event) {
+  function downscaleImage(file) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const img = new Image();
+        img.onload = () => {
+          const MAX_DIMENSION = 1200;
+          const scale = Math.min(1, MAX_DIMENSION / Math.max(img.width, img.height));
+          const targetWidth = Math.round(img.width * scale);
+          const targetHeight = Math.round(img.height * scale);
+          const canvas = document.createElement("canvas");
+          canvas.width = targetWidth;
+          canvas.height = targetHeight;
+          const ctx = canvas.getContext("2d");
+          ctx.drawImage(img, 0, 0, targetWidth, targetHeight);
+          const outputType = file.type === "image/png" ? "image/png" : "image/jpeg";
+          const quality = outputType === "image/png" ? 0.9 : 0.85;
+          const dataUrl = canvas.toDataURL(outputType, quality);
+          resolve(dataUrl);
+        };
+        img.onerror = () => reject(new Error("画像の読み込みに失敗しました。"));
+        img.src = reader.result;
+      };
+      reader.onerror = () => reject(new Error("画像の読み込みに失敗しました。"));
+      reader.readAsDataURL(file);
+    });
+  }
+
+  async function handleFileSelect(event) {
     const [file] = event.target.files || [];
     if (!file) return;
     if (!file.type.startsWith("image/")) {
@@ -173,12 +282,15 @@
       imageStatus.textContent = "3MB以下の画像をアップロードしてください。";
       return;
     }
-    const reader = new FileReader();
-    reader.onload = () => {
+    imageStatus.textContent = "画像を読み込み中です…";
+    try {
+      const scaled = await downscaleImage(file);
       imageInput.value = "";
-      setPreview(reader.result);
-    };
-    reader.readAsDataURL(file);
+      setPreview(scaled);
+      imageStatus.textContent = "長辺1200pxに自動リサイズして保存します。";
+    } catch (err) {
+      imageStatus.textContent = err?.message || "画像処理に失敗しました。";
+    }
   }
 
   function setSessionBadge() {
@@ -241,6 +353,17 @@
     });
 
     settingsStatus.textContent = `ヒーロー: ${Number.isInteger(settings.heroId) ? `ID ${settings.heroId}` : "未指定"} / 注目: ${Number.isInteger(settings.featuredId) ? `ID ${settings.featuredId}` : "未指定"} / 固定 ${settings.footerIds.length} 件`;
+  }
+
+  function renderCopyForm() {
+    const copy = BlogData.loadCopy();
+    Object.entries(copy).forEach(([key, value]) => {
+      const input = copyForm.querySelector(`[name="${key}"]`);
+      if (input) {
+        input.value = value;
+      }
+    });
+    copyStatus.textContent = "一覧ページに即時反映されます。";
   }
 
   function renderList() {
@@ -335,11 +458,27 @@
     settingsStatus.textContent = `ヒーロー: ${Number.isInteger(normalized.heroId) ? `ID ${normalized.heroId}` : "未指定"} / 注目: ${Number.isInteger(normalized.featuredId) ? `ID ${normalized.featuredId}` : "未指定"} / 固定 ${normalized.footerIds.length} 件 保存しました`;
   }
 
+  function handleCopySave(event) {
+    event.preventDefault();
+    const formData = new FormData(copyForm);
+    const payload = {};
+    for (const [key, value] of formData.entries()) {
+      payload[key] = value;
+    }
+    const normalized = BlogData.saveCopy(payload);
+    copyStatus.textContent = "保存しました。ブログ一覧で即座に反映されます。";
+    Object.entries(normalized).forEach(([key, value]) => {
+      const input = copyForm.querySelector(`[name="${key}"]`);
+      if (input) input.value = value;
+    });
+  }
+
   document.addEventListener("DOMContentLoaded", () => {
     setSessionBadge();
     renderList();
     fillForm({}, null);
     renderSettingsForm();
+    renderCopyForm();
   });
 
   form.addEventListener("submit", handleSave);
@@ -353,6 +492,7 @@
   });
   document.getElementById("newBtn").addEventListener("click", () => fillForm({}, null));
   settingsForm.addEventListener("submit", handleSettingsSave);
+  copyForm.addEventListener("submit", handleCopySave);
 </script>
 </body>
 </html>

--- a/public/blog-list.html
+++ b/public/blog-list.html
@@ -28,8 +28,8 @@
       </div>
       <div class="grid-2" style="align-items:center;">
         <div class="stack" style="gap:10px;" id="featuredCopy">
-          <h2>幅に合わせて表情を変える一覧ビュー</h2>
-          <p>スマホでは縦にカードを並べ、タブレットはサムネイル横並び、PCではサイドバー付きの2カラムで統計とタグクラウドを固定。見やすさを保ちながら情報量を増やしました。</p>
+          <h2 id="heroTitle">幅に合わせて表情を変える一覧ビュー</h2>
+          <p id="heroBody">スマホでは縦にカードを並べ、タブレットはサムネイル横並び、PCではサイドバー付きの2カラムで統計とタグクラウドを固定。見やすさを保ちながら情報量を増やしました。</p>
           <div class="inline-chips">
             <span class="badge">LINE連携</span>
             <span class="badge">ローカル保存</span>
@@ -42,20 +42,20 @@
 
     <section class="grid-2">
       <article class="card">
-        <h3>スマホビュー</h3>
-        <p class="mobile-hint">1カラムでサムネイルを上、本文とタグを下に配置。タップしやすい余白を確保しました。</p>
+        <h3 id="mobileTitle">スマホビュー</h3>
+        <p class="mobile-hint" id="mobileBody">1カラムでサムネイルを上、本文とタグを下に配置。タップしやすい余白を確保しました。</p>
       </article>
       <article class="card">
-        <h3>タブレットビュー</h3>
-        <p class="tablet-hint">サムネイル横並び＋行間拡大。768px以上で自動適用されます。</p>
+        <h3 id="tabletTitle">タブレットビュー</h3>
+        <p class="tablet-hint" id="tabletBody">サムネイル横並び＋行間拡大。768px以上で自動適用されます。</p>
       </article>
       <article class="card">
-        <h3>PCビュー</h3>
-        <p class="pc-hint">最大幅1200pxで2カラム＋サイドバーを固定。タグクラウドと統計を右側に表示します。</p>
+        <h3 id="pcTitle">PCビュー</h3>
+        <p class="pc-hint" id="pcBody">最大幅1200pxで2カラム＋サイドバーを固定。タグクラウドと統計を右側に表示します。</p>
       </article>
       <article class="card">
-        <h3>共有と導線</h3>
-        <p>各記事にLINE共有と記事リンクを配置。管理者リンクは認証が必要な場合のみ遷移します。</p>
+        <h3 id="shareTitle">共有と導線</h3>
+        <p id="shareBody">各記事にLINE共有と記事リンクを配置。管理者リンクは認証が必要な場合のみ遷移します。</p>
       </article>
     </section>
 
@@ -63,8 +63,8 @@
       <div class="list-shell">
         <div class="list-head">
           <div>
-            <h3>最新の投稿</h3>
-            <p class="muted">ローカル保存された記事を時系列順に一覧表示します。</p>
+            <h3 id="listTitle">最新の投稿</h3>
+            <p class="muted" id="listSubtitle">ローカル保存された記事を時系列順に一覧表示します。</p>
           </div>
           <div class="badge" id="countBadge"></div>
         </div>
@@ -74,8 +74,8 @@
       <aside class="stack" aria-label="サイド情報">
         <div class="panel">
           <div class="section-title" style="gap:6px;">
-            <h3>タグクラウド</h3>
-            <span class="tiny">使用頻度順に表示</span>
+            <h3 id="tagTitle">タグクラウド</h3>
+            <span class="tiny" id="tagSubtitle">使用頻度順に表示</span>
           </div>
           <div class="tag-row" id="tagCloud"></div>
         </div>
@@ -84,8 +84,8 @@
 
     <section class="panel" id="pinnedWrapper" style="display:none;">
       <div class="section-title">
-        <h3>固定記事</h3>
-        <span class="tiny">管理ページで選択された記事を表示</span>
+        <h3 id="pinnedTitle">固定記事</h3>
+        <span class="tiny" id="pinnedSubtitle">管理ページで選択された記事を表示</span>
       </div>
       <div class="list card-layout" id="pinnedList"></div>
     </section>
@@ -105,6 +105,27 @@
     const featuredVisual = document.getElementById("featuredVisual");
     const pinnedWrapper = document.getElementById("pinnedWrapper");
     const pinnedList = document.getElementById("pinnedList");
+    const copyTexts = BlogData.loadCopy();
+
+    function applyCopy() {
+      const safeText = (value, fallback) => (value ?? fallback);
+      document.getElementById("heroTitle").textContent = safeText(copyTexts.heroTitle, "");
+      document.getElementById("heroBody").textContent = safeText(copyTexts.heroBody, "");
+      document.getElementById("mobileTitle").textContent = safeText(copyTexts.mobileTitle, "");
+      document.getElementById("mobileBody").textContent = safeText(copyTexts.mobileBody, "");
+      document.getElementById("tabletTitle").textContent = safeText(copyTexts.tabletTitle, "");
+      document.getElementById("tabletBody").textContent = safeText(copyTexts.tabletBody, "");
+      document.getElementById("pcTitle").textContent = safeText(copyTexts.pcTitle, "");
+      document.getElementById("pcBody").textContent = safeText(copyTexts.pcBody, "");
+      document.getElementById("shareTitle").textContent = safeText(copyTexts.shareTitle, "");
+      document.getElementById("shareBody").textContent = safeText(copyTexts.shareBody, "");
+      document.getElementById("listTitle").textContent = safeText(copyTexts.listTitle, "");
+      document.getElementById("listSubtitle").textContent = safeText(copyTexts.listSubtitle, "");
+      document.getElementById("pinnedTitle").textContent = safeText(copyTexts.pinnedTitle, "");
+      document.getElementById("pinnedSubtitle").textContent = safeText(copyTexts.pinnedSubtitle, "");
+      document.getElementById("tagTitle").textContent = safeText(copyTexts.tagTitle, "");
+      document.getElementById("tagSubtitle").textContent = safeText(copyTexts.tagSubtitle, "");
+    }
 
     function enforceAdminLinks() {
       const adminLinks = document.querySelectorAll('[data-requires-auth]');
@@ -121,6 +142,8 @@
         });
       });
     }
+
+    applyCopy();
 
     function formatRelative(index) {
       const base = Date.now() - index * 3_600_000 * 3;


### PR DESCRIPTION
## Summary
- automatically downscale uploaded images in the admin editor before previewing and saving
- add management form to edit blog list copy and persist it in localStorage
- display customizable copy on the public blog list page using saved values

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69429085f2388321b93a7faa4419d4e0)