### PR TITLE
Fix swipe delete gesture direction

### DIFF
--- a/public/blog-edit.html
+++ b/public/blog-edit.html
@@ -472,9 +472,9 @@
 
     element.addEventListener("pointermove", (event) => {
       if (!dragging) return;
-      deltaX = Math.max(0, event.clientX - startX);
+      deltaX = Math.max(0, startX - event.clientX);
       if (!body) return;
-      body.style.transform = `translateX(${Math.min(deltaX, 120)}px)`;
+      body.style.transform = `translateX(${-Math.min(deltaX, 120)}px)`;
       element.dataset.swipeReady = deltaX > 80 ? "true" : "";
     });
 


### PR DESCRIPTION
## Summary
- adjust swipe handling on admin copy extras to respond to right-to-left gestures
- keep delete affordance revealed when swiping to the right from the starting point

## Testing
- not run (UI change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942970528488321a21f10f8d274ec11)