### PR TITLE
Add per-session delete controls for chat TOC

### DIFF
--- a/Chat/Index.html
+++ b/Chat/Index.html
@@ -394,6 +394,20 @@
       color: #6b7280;
     }
 
+    .toc-item-actions {
+      display: flex;
+      gap: 6px;
+      margin-left: auto;
+      align-items: center;
+      opacity: 0;
+      transition: opacity 0.15s ease;
+    }
+
+    .toc-item:hover .toc-item-actions,
+    .toc-item:focus-within .toc-item-actions {
+      opacity: 1;
+    }
+
     .content-panel {
       border-radius: var(--radius-lg);
       background: radial-gradient(circle at top right, rgba(30,64,175,0.3), #020617);
@@ -442,6 +456,14 @@
       background: radial-gradient(circle at top left, rgba(56,189,248,0.18), rgba(15,23,42,0.95));
     }
 
+    .conversation-head {
+      display: flex;
+      gap: 10px;
+      align-items: flex-start;
+      justify-content: space-between;
+      flex-wrap: wrap;
+    }
+
     .conversation-title {
       font-size: 12px;
       font-weight: 600;
@@ -457,6 +479,35 @@
     .conversation-body {
       font-size: 12px;
       color: #e5e7eb;
+    }
+
+    .icon-btn {
+      background: rgba(30, 41, 59, 0.8);
+      color: #e5e7eb;
+      border: 1px solid rgba(148, 163, 184, 0.4);
+      border-radius: 8px;
+      padding: 6px 8px;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 12px;
+      transition: all 0.15s ease;
+    }
+
+    .icon-btn:hover {
+      background: rgba(30, 41, 59, 1);
+      border-color: rgba(148, 163, 184, 0.7);
+    }
+
+    .icon-btn.danger {
+      color: #fecdd3;
+      border-color: rgba(248, 113, 113, 0.5);
+      background: rgba(248, 113, 113, 0.08);
+    }
+
+    .icon-btn.danger:hover {
+      background: rgba(248, 113, 113, 0.14);
     }
 
     .badge {
@@ -754,6 +805,10 @@ Assistant: ...
     const contentBodyEl = document.getElementById('contentBody');
     const contentMetaEl = document.getElementById('contentMeta');
 
+    function reindexConversations(list) {
+      return list.map((conv, idx) => ({ ...conv, id: idx }));
+    }
+
     function setStatus(mode, text) {
       if (mode === 'busy') {
         statusDotEl.classList.remove('idle');
@@ -919,9 +974,24 @@ Assistant: ...
           const length = conv.body.length;
           metaEl.textContent = length + '字';
 
+          const actionsEl = document.createElement('div');
+          actionsEl.className = 'toc-item-actions';
+
+          const deleteBtn = document.createElement('button');
+          deleteBtn.className = 'icon-btn danger';
+          deleteBtn.type = 'button';
+          deleteBtn.innerHTML = '🗑️ 削除';
+          deleteBtn.addEventListener('click', (event) => {
+            event.stopPropagation();
+            deleteConversation(conv.id);
+          });
+
+          actionsEl.appendChild(deleteBtn);
+
           itemEl.appendChild(prefixEl);
           itemEl.appendChild(titleEl);
           itemEl.appendChild(metaEl);
+          itemEl.appendChild(actionsEl);
 
           itemEl.addEventListener('click', () => {
             focusConversation(conv.id);
@@ -959,6 +1029,9 @@ Assistant: ...
         blockEl.className = 'conversation-block';
         blockEl.id = 'conv-' + conv.id;
 
+        const headEl = document.createElement('div');
+        headEl.className = 'conversation-head';
+
         const titleEl = document.createElement('div');
         titleEl.className = 'conversation-title';
         titleEl.textContent = '#' + (conv.id + 1) + ' ' + conv.title;
@@ -968,11 +1041,28 @@ Assistant: ...
         metaEl.textContent = categoryEmoji(conv.category) + ' ' + categoryLabel(conv.category) +
           ' ｜ ' + conv.body.length + '字';
 
+        const actionsEl = document.createElement('div');
+        actionsEl.className = 'toc-item-actions';
+
+        const deleteBtn = document.createElement('button');
+        deleteBtn.className = 'icon-btn danger';
+        deleteBtn.type = 'button';
+        deleteBtn.innerHTML = '🗑️ 削除';
+        deleteBtn.addEventListener('click', (event) => {
+          event.stopPropagation();
+          deleteConversation(conv.id);
+        });
+
+        actionsEl.appendChild(deleteBtn);
+
+        headEl.appendChild(titleEl);
+        headEl.appendChild(actionsEl);
+
         const bodyEl = document.createElement('div');
         bodyEl.className = 'conversation-body';
         bodyEl.textContent = conv.body;
 
-        blockEl.appendChild(titleEl);
+        blockEl.appendChild(headEl);
         blockEl.appendChild(metaEl);
         blockEl.appendChild(bodyEl);
 
@@ -1014,6 +1104,20 @@ Assistant: ...
           block: 'start'
         });
       }
+    }
+
+    function deleteConversation(convId) {
+      const nextConvs = conversations.filter(conv => conv.id !== convId);
+      conversations = reindexConversations(nextConvs);
+      activeConvId = null;
+
+      renderTOC(conversations);
+      renderContent(conversations);
+
+      const message = conversations.length
+        ? `削除しました。残り ${conversations.length} 件。`
+        : 'すべてのセッションを削除しました。';
+      setStatus('idle', message);
     }
 
     analyzeBtn.addEventListener('click', () => {

--- a/public/chat-toc.html
+++ b/public/chat-toc.html
@@ -433,8 +433,22 @@
     }
 
     .toc-item-meta {
-     	font-size: 9px;
-     	color: #6b7280;
+        font-size: 9px;
+        color: #6b7280;
+    }
+
+    .toc-item-actions {
+        display: flex;
+        gap: 6px;
+        margin-left: auto;
+        align-items: center;
+        opacity: 0;
+        transition: opacity 0.15s ease;
+    }
+
+    .toc-item:hover .toc-item-actions,
+    .toc-item:focus-within .toc-item-actions {
+        opacity: 1;
     }
 
     .content-panel {
@@ -480,9 +494,17 @@
     }
 
     .conversation-block.highlight {
-     	border-color: rgba(56,189,248,0.9);
-     	box-shadow: 0 0 0 1px rgba(56,189,248,0.6);
-     	background: radial-gradient(circle at top left, rgba(56,189,248,0.18), rgba(15,23,42,0.95));
+        border-color: rgba(56,189,248,0.9);
+        box-shadow: 0 0 0 1px rgba(56,189,248,0.6);
+        background: radial-gradient(circle at top left, rgba(56,189,248,0.18), rgba(15,23,42,0.95));
+    }
+
+    .conversation-head {
+        display: flex;
+        gap: 10px;
+        align-items: flex-start;
+        justify-content: space-between;
+        flex-wrap: wrap;
     }
 
     .conversation-title {
@@ -498,8 +520,37 @@
     }
 
     .conversation-body {
-     	font-size: 12px;
-     	color: #e5e7eb;
+        font-size: 12px;
+        color: #e5e7eb;
+    }
+
+    .icon-btn {
+        background: rgba(30, 41, 59, 0.8);
+        color: #e5e7eb;
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        border-radius: 8px;
+        padding: 6px 8px;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 12px;
+        transition: all 0.15s ease;
+    }
+
+    .icon-btn:hover {
+        background: rgba(30, 41, 59, 1);
+        border-color: rgba(148, 163, 184, 0.7);
+    }
+
+    .icon-btn.danger {
+        color: #fecdd3;
+        border-color: rgba(248, 113, 113, 0.5);
+        background: rgba(248, 113, 113, 0.08);
+    }
+
+    .icon-btn.danger:hover {
+        background: rgba(248, 113, 113, 0.14);
     }
 
     .badge-pill {
@@ -731,6 +782,10 @@ Assistant: ...
     const contentBodyEl = document.getElementById('contentBody');
     const contentMetaEl = document.getElementById('contentMeta');
 
+    function reindexConversations(list) {
+      return list.map((conv, idx) => ({ ...conv, id: idx }));
+    }
+
     function setStatus(mode, text) {
       if (mode === 'busy') {
         statusDotEl.classList.remove('idle');
@@ -896,9 +951,24 @@ Assistant: ...
           const length = conv.body.length;
           metaEl.textContent = length + '字';
 
+          const actionsEl = document.createElement('div');
+          actionsEl.className = 'toc-item-actions';
+
+          const deleteBtn = document.createElement('button');
+          deleteBtn.className = 'icon-btn danger';
+          deleteBtn.type = 'button';
+          deleteBtn.innerHTML = '🗑️ 削除';
+          deleteBtn.addEventListener('click', (event) => {
+            event.stopPropagation();
+            deleteConversation(conv.id);
+          });
+
+          actionsEl.appendChild(deleteBtn);
+
           itemEl.appendChild(prefixEl);
           itemEl.appendChild(titleEl);
           itemEl.appendChild(metaEl);
+          itemEl.appendChild(actionsEl);
 
           itemEl.addEventListener('click', () => {
             focusConversation(conv.id);
@@ -936,6 +1006,9 @@ Assistant: ...
         blockEl.className = 'conversation-block';
         blockEl.id = 'conv-' + conv.id;
 
+        const headEl = document.createElement('div');
+        headEl.className = 'conversation-head';
+
         const titleEl = document.createElement('div');
         titleEl.className = 'conversation-title';
         titleEl.textContent = '#' + (conv.id + 1) + ' ' + conv.title;
@@ -945,11 +1018,28 @@ Assistant: ...
         metaEl.textContent = categoryEmoji(conv.category) + ' ' + categoryLabel(conv.category) +
           ' ｜ ' + conv.body.length + '字';
 
+        const actionsEl = document.createElement('div');
+        actionsEl.className = 'toc-item-actions';
+
+        const deleteBtn = document.createElement('button');
+        deleteBtn.className = 'icon-btn danger';
+        deleteBtn.type = 'button';
+        deleteBtn.innerHTML = '🗑️ 削除';
+        deleteBtn.addEventListener('click', (event) => {
+          event.stopPropagation();
+          deleteConversation(conv.id);
+        });
+
+        actionsEl.appendChild(deleteBtn);
+
+        headEl.appendChild(titleEl);
+        headEl.appendChild(actionsEl);
+
         const bodyEl = document.createElement('div');
         bodyEl.className = 'conversation-body';
         bodyEl.textContent = conv.body;
 
-        blockEl.appendChild(titleEl);
+        blockEl.appendChild(headEl);
         blockEl.appendChild(metaEl);
         blockEl.appendChild(bodyEl);
 
@@ -991,6 +1081,20 @@ Assistant: ...
           block: 'start'
         });
       }
+    }
+
+    function deleteConversation(convId) {
+      const nextConvs = conversations.filter(conv => conv.id !== convId);
+      conversations = reindexConversations(nextConvs);
+      activeConvId = null;
+
+      renderTOC(conversations);
+      renderContent(conversations);
+
+      const message = conversations.length
+        ? `削除しました。残り ${conversations.length} 件。`
+        : 'すべてのセッションを削除しました。';
+      setStatus('idle', message);
     }
 
     analyzeBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add inline delete buttons to chat session listings and content blocks
- reindex and refresh the session list after deletions while updating status messaging
- style the new action buttons for visibility on hover

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69429920d71c832194b479e95d089f79)