### PR TITLE
Allow clearing copy text fields in blog admin

### DIFF
--- a/public/blog-edit.html
+++ b/public/blog-edit.html
@@ -78,67 +78,67 @@
         <div class="grid-2" style="gap:12px;">
           <div class="form-row">
             <label class="tiny" for="heroTitle">ヒーロータイトル</label>
-            <input id="heroTitle" name="heroTitle" required>
+            <input id="heroTitle" name="heroTitle">
           </div>
           <div class="form-row">
             <label class="tiny" for="heroBody">ヒーロー本文</label>
-            <textarea id="heroBody" name="heroBody" required></textarea>
+            <textarea id="heroBody" name="heroBody"></textarea>
           </div>
           <div class="form-row">
             <label class="tiny" for="mobileTitle">スマホ見出し</label>
-            <input id="mobileTitle" name="mobileTitle" required>
+            <input id="mobileTitle" name="mobileTitle">
           </div>
           <div class="form-row">
             <label class="tiny" for="mobileBody">スマホ本文</label>
-            <textarea id="mobileBody" name="mobileBody" required></textarea>
+            <textarea id="mobileBody" name="mobileBody"></textarea>
           </div>
           <div class="form-row">
             <label class="tiny" for="tabletTitle">タブレット見出し</label>
-            <input id="tabletTitle" name="tabletTitle" required>
+            <input id="tabletTitle" name="tabletTitle">
           </div>
           <div class="form-row">
             <label class="tiny" for="tabletBody">タブレット本文</label>
-            <textarea id="tabletBody" name="tabletBody" required></textarea>
+            <textarea id="tabletBody" name="tabletBody"></textarea>
           </div>
           <div class="form-row">
             <label class="tiny" for="pcTitle">PC見出し</label>
-            <input id="pcTitle" name="pcTitle" required>
+            <input id="pcTitle" name="pcTitle">
           </div>
           <div class="form-row">
             <label class="tiny" for="pcBody">PC本文</label>
-            <textarea id="pcBody" name="pcBody" required></textarea>
+            <textarea id="pcBody" name="pcBody"></textarea>
           </div>
           <div class="form-row">
             <label class="tiny" for="shareTitle">共有セクション見出し</label>
-            <input id="shareTitle" name="shareTitle" required>
+            <input id="shareTitle" name="shareTitle">
           </div>
           <div class="form-row">
             <label class="tiny" for="shareBody">共有セクション本文</label>
-            <textarea id="shareBody" name="shareBody" required></textarea>
+            <textarea id="shareBody" name="shareBody"></textarea>
           </div>
           <div class="form-row">
             <label class="tiny" for="listTitle">一覧セクション見出し</label>
-            <input id="listTitle" name="listTitle" required>
+            <input id="listTitle" name="listTitle">
           </div>
           <div class="form-row">
             <label class="tiny" for="listSubtitle">一覧セクション補足</label>
-            <textarea id="listSubtitle" name="listSubtitle" required></textarea>
+            <textarea id="listSubtitle" name="listSubtitle"></textarea>
           </div>
           <div class="form-row">
             <label class="tiny" for="pinnedTitle">固定セクション見出し</label>
-            <input id="pinnedTitle" name="pinnedTitle" required>
+            <input id="pinnedTitle" name="pinnedTitle">
           </div>
           <div class="form-row">
             <label class="tiny" for="pinnedSubtitle">固定セクション補足</label>
-            <textarea id="pinnedSubtitle" name="pinnedSubtitle" required></textarea>
+            <textarea id="pinnedSubtitle" name="pinnedSubtitle"></textarea>
           </div>
           <div class="form-row">
             <label class="tiny" for="tagTitle">タグクラウド見出し</label>
-            <input id="tagTitle" name="tagTitle" required>
+            <input id="tagTitle" name="tagTitle">
           </div>
           <div class="form-row">
             <label class="tiny" for="tagSubtitle">タグクラウド補足</label>
-            <textarea id="tagSubtitle" name="tagSubtitle" required></textarea>
+            <textarea id="tagSubtitle" name="tagSubtitle"></textarea>
           </div>
         </div>
         <div class="actions" style="justify-content: space-between; align-items: center; flex-wrap: wrap;">


### PR DESCRIPTION
## Summary
- allow text copy fields in the admin editor to be saved empty so sections can be cleared from the UI

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69429cea45648321b9a1aff6a638d65d)