### PR TITLE
Add admin controls for homepage articles

### DIFF
--- a/public/blog-edit.html
+++ b/public/blog-edit.html
@@ -59,6 +59,16 @@
           <select id="featuredSelect"></select>
         </div>
         <div class="form-row">
+          <label class="tiny" for="homeFeaturedSelect">トップページの注目記事（横スクロール枠 / 最大4件）</label>
+          <select id="homeFeaturedSelect" multiple size="5"></select>
+          <p class="tiny muted">Cmd/Ctrl + クリックで複数選択できます。最大4件まで優先表示します。</p>
+        </div>
+        <div class="form-row">
+          <label class="tiny" for="homeLatestSelect">トップページの最新記事（リスト表示 / 最大4件）</label>
+          <select id="homeLatestSelect" multiple size="5"></select>
+          <p class="tiny muted">選択されたID順で表示します（未選択の場合は先頭から4件）。</p>
+        </div>
+        <div class="form-row">
           <label class="tiny">固定記事（一覧の最下部に並べます）</label>
           <div id="pinnedChoices" class="stack" style="gap:8px;"></div>
         </div>
@@ -229,6 +239,8 @@
   const settingsForm = document.getElementById("settingsForm");
   const heroSelect = document.getElementById("heroSelect");
   const featuredSelect = document.getElementById("featuredSelect");
+  const homeFeaturedSelect = document.getElementById("homeFeaturedSelect");
+  const homeLatestSelect = document.getElementById("homeLatestSelect");
   const pinnedChoices = document.getElementById("pinnedChoices");
   const settingsStatus = document.getElementById("settingsStatus");
   const copyForm = document.getElementById("copyForm");
@@ -325,11 +337,15 @@
     const settings = BlogData.saveSettings(BlogData.loadSettings());
     heroSelect.innerHTML = "";
     featuredSelect.innerHTML = "";
+    homeFeaturedSelect.innerHTML = "";
+    homeLatestSelect.innerHTML = "";
     pinnedChoices.innerHTML = "";
 
     if (!articles.length) {
       heroSelect.innerHTML = '<option value="">記事がありません</option>';
       featuredSelect.innerHTML = '<option value="">記事がありません</option>';
+      homeFeaturedSelect.innerHTML = '<option value="">記事がありません</option>';
+      homeLatestSelect.innerHTML = '<option value="">記事がありません</option>';
       pinnedChoices.innerHTML = '<span class="tiny">記事追加後に設定できます。</span>';
       settingsStatus.textContent = "記事を追加すると設定できます。";
       return;
@@ -357,6 +373,18 @@
       opt.textContent = `ID ${idx}: ${article.title || "無題"}`;
       if (settings.featuredId === idx) opt.selected = true;
       featuredSelect.appendChild(opt);
+
+      const featuredOpt = document.createElement("option");
+      featuredOpt.value = String(idx);
+      featuredOpt.textContent = `ID ${idx}: ${article.title || "無題"}`;
+      featuredOpt.selected = settings.homeFeaturedIds.includes(idx);
+      homeFeaturedSelect.appendChild(featuredOpt);
+
+      const latestOpt = document.createElement("option");
+      latestOpt.value = String(idx);
+      latestOpt.textContent = `ID ${idx}: ${article.title || "無題"}`;
+      latestOpt.selected = settings.homeLatestIds.includes(idx);
+      homeLatestSelect.appendChild(latestOpt);
     });
 
     articles.forEach((article, idx) => {
@@ -374,7 +402,7 @@
       pinnedChoices.appendChild(row);
     });
 
-    settingsStatus.textContent = `ヒーロー: ${Number.isInteger(settings.heroId) ? `ID ${settings.heroId}` : "未指定"} / 注目: ${Number.isInteger(settings.featuredId) ? `ID ${settings.featuredId}` : "未指定"} / 固定 ${settings.footerIds.length} 件`;
+    settingsStatus.textContent = `ヒーロー: ${Number.isInteger(settings.heroId) ? `ID ${settings.heroId}` : "未指定"} / 注目: ${Number.isInteger(settings.featuredId) ? `ID ${settings.featuredId}` : "未指定"} / トップ注目 ${settings.homeFeaturedIds.length} 件 / トップ最新 ${settings.homeLatestIds.length} 件 / 固定 ${settings.footerIds.length} 件`;
   }
 
   function renderCopyForm() {
@@ -581,8 +609,14 @@
     const footerIds = Array.from(pinnedChoices.querySelectorAll('input[type="checkbox"]:checked'))
       .map((input) => parseInt(input.value, 10))
       .filter(Number.isInteger);
-    const normalized = BlogData.saveSettings({ heroId, featuredId, footerIds });
-    settingsStatus.textContent = `ヒーロー: ${Number.isInteger(normalized.heroId) ? `ID ${normalized.heroId}` : "未指定"} / 注目: ${Number.isInteger(normalized.featuredId) ? `ID ${normalized.featuredId}` : "未指定"} / 固定 ${normalized.footerIds.length} 件 保存しました`;
+    const homeFeaturedIds = Array.from(homeFeaturedSelect.selectedOptions)
+      .map((opt) => parseInt(opt.value, 10))
+      .filter(Number.isInteger);
+    const homeLatestIds = Array.from(homeLatestSelect.selectedOptions)
+      .map((opt) => parseInt(opt.value, 10))
+      .filter(Number.isInteger);
+    const normalized = BlogData.saveSettings({ heroId, featuredId, footerIds, homeFeaturedIds, homeLatestIds });
+    settingsStatus.textContent = `ヒーロー: ${Number.isInteger(normalized.heroId) ? `ID ${normalized.heroId}` : "未指定"} / 注目: ${Number.isInteger(normalized.featuredId) ? `ID ${normalized.featuredId}` : "未指定"} / トップ注目 ${normalized.homeFeaturedIds.length} 件 / トップ最新 ${normalized.homeLatestIds.length} 件 / 固定 ${normalized.footerIds.length} 件 保存しました`;
   }
 
   function handleCopySave(event) {

--- a/public/index.html
+++ b/public/index.html
@@ -40,48 +40,7 @@
         <h2>注目記事</h2>
         <span class="muted">横スクロールでチェック</span>
       </div>
-      <div class="scroll-row">
-        <article class="featured-card">
-          <div class="featured-thumb" aria-hidden="true"></div>
-          <div class="featured-pill">特集</div>
-          <h3>生成AIで記事制作を高速化</h3>
-          <p>編集部のワークフローを自動化し、下書き生成から校閲まで一気通貫で支援する最新ツールをレビュー。</p>
-          <div class="featured-meta">
-            <span>テック / プロダクト</span>
-            <span>8分</span>
-          </div>
-        </article>
-        <article class="featured-card gradient-blue">
-          <div class="featured-thumb" aria-hidden="true"></div>
-          <div class="featured-pill">インタビュー</div>
-          <h3>著名ブロガーが語る「書き続ける理由」</h3>
-          <p>PVや収益だけではない、ファンとの共創や長期のブランド形成をどう捉えているのかを深堀りしました。</p>
-          <div class="featured-meta">
-            <span>カルチャー</span>
-            <span>6分</span>
-          </div>
-        </article>
-        <article class="featured-card gradient-gold">
-          <div class="featured-thumb" aria-hidden="true"></div>
-          <div class="featured-pill">速報</div>
-          <h3>新デバイス発表イベントをリアルタイム更新</h3>
-          <p>現地からの写真と試用インプレッションを随時更新。UI/UXの細部をスクリーンショット付きで追います。</p>
-          <div class="featured-meta">
-            <span>ガジェット</span>
-            <span>ライブ</span>
-          </div>
-        </article>
-        <article class="featured-card gradient-purple">
-          <div class="featured-thumb" aria-hidden="true"></div>
-          <div class="featured-pill">連載</div>
-          <h3>デザインシステム刷新の舞台裏</h3>
-          <p>統一されたコンポーネント設計とアクセシビリティ改善を、実装例とともにシリーズで解説します。</p>
-          <div class="featured-meta">
-            <span>UI/UX</span>
-            <span>10分</span>
-          </div>
-        </article>
-      </div>
+      <div class="scroll-row" id="featuredRow"></div>
     </section>
 
     <section class="section">
@@ -173,6 +132,7 @@
     const heroActions = document.getElementById("heroActions");
     const heroBadge = document.getElementById("heroBadge");
     const heroMeta = document.getElementById("heroMeta");
+    const featuredRow = document.getElementById("featuredRow");
 
     const heroFallback = {
       title: "全ページをレスポンシブで作り直しました",
@@ -189,7 +149,8 @@
     }
 
     function renderLatestList() {
-      const articles = BlogData.loadArticles();
+      const latest = BlogData.getHomeLatestArticles();
+      const articles = latest.list;
       latestList.innerHTML = "";
 
       if (!articles.length) {
@@ -197,8 +158,8 @@
         return;
       }
 
-      articles.slice(0, 4).forEach((article, idx) => {
-        const isLatest = idx === 0;
+      articles.forEach(({ article, idx }, orderIdx) => {
+        const isLatest = orderIdx === 0;
         const primaryTag = article.tags?.[0];
         const detailLink = `/blog-article.html?id=${idx}`;
         const card = document.createElement("article");
@@ -216,6 +177,45 @@
           </div>
         `;
         latestList.appendChild(card);
+      });
+    }
+
+    function renderFeaturedRow() {
+      const featured = BlogData.getHomeFeaturedArticles();
+      const articles = featured.list;
+      featuredRow.innerHTML = "";
+
+      if (!articles.length) {
+        featuredRow.innerHTML = '<p class="muted">記事を追加して注目枠を設定してください。</p>';
+        return;
+      }
+
+      const gradients = ["", "gradient-blue", "gradient-gold", "gradient-purple"];
+
+      articles.forEach(({ article, idx }, orderIdx) => {
+        const card = document.createElement("article");
+        const gradient = gradients[orderIdx % gradients.length];
+        card.className = `featured-card ${gradient}`.trim();
+        const cover = article.image
+          ? `<div class="featured-thumb" aria-hidden="true" style="background-image: url(${article.image}); background-size: cover; background-position: center;"></div>`
+          : '<div class="featured-thumb fallback" aria-hidden="true">NO IMAGE</div>';
+        const primaryTag = article.tags?.[0];
+        const secondaryTag = article.tags?.[1];
+        const articleUrl = `/blog-article.html?id=${idx}`;
+        card.innerHTML = `
+          ${cover}
+          <div class="featured-pill">ID ${idx}</div>
+          <h3>${article.title || "無題の記事"}</h3>
+          <p>${article.body || "本文がありません"}</p>
+          <div class="featured-meta">
+            <span>${primaryTag ? `#${primaryTag}` : "タグなし"}</span>
+            <span>${secondaryTag ? `#${secondaryTag}` : "選択順 ${orderIdx + 1}"}</span>
+          </div>
+          <div class="actions" style="margin-top:8px;">
+            <a class="button ghost" href="${articleUrl}">記事を読む</a>
+          </div>
+        `;
+        featuredRow.appendChild(card);
       });
     }
 
@@ -273,6 +273,7 @@
     document.addEventListener("DOMContentLoaded", () => {
       renderHeroFromArticle();
       renderLatestList();
+      renderFeaturedRow();
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- let admins pick homepage featured and latest article IDs via new multi-select controls in the settings panel
- persist configured selections in article settings and expose helpers for the homepage to consume
- render the homepage featured carousel and latest list from the selected article IDs with graceful fallbacks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69429fc118f8832185a796b957c30c9a)