### PR TITLE
Remove static device feature cards from home

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -53,29 +53,6 @@
       </div>
     </section>
 
-    <section class="grid-2">
-      <article class="card">
-        <div class="badge">スマホビュー</div>
-        <h3>タップしやすい縦積み</h3>
-        <p>1カラム構成と大きめのタッチターゲットで、iPhoneサイズでも余白にゆとりを持たせています。横スクロールの特集カードも指で操作しやすい幅に調整。</p>
-      </article>
-      <article class="card">
-        <div class="badge">タブレットビュー</div>
-        <h3>横幅を活かした2カラム</h3>
-        <p>768〜1024px帯では、サムネイルと本文を横並びにし、サイドメタ情報も表示。Splitレイアウトで情報量と読みやすさを両立しています。</p>
-      </article>
-      <article class="card">
-        <div class="badge">PCビュー</div>
-        <h3>最大幅1200pxのワイドUI</h3>
-        <p>記事一覧＋サイドバー、エディタとプレビューなど、PCでの操作性を優先した配置に。固定ヘッダーと段階的な余白で視線移動を最小化します。</p>
-      </article>
-      <article class="card">
-        <div class="badge">管理・ツール</div>
-        <h3>描画・チャット TOC も統一デザイン</h3>
-        <p>管理ログイン、ブログ編集、描画ツール、チャットTOCメーカーも新しいベースレイアウトを適用。すべての機能が同じUI部品でまとまりました。</p>
-      </article>
-    </section>
-
     <section class="section">
       <div class="section-title">
         <h2>ページリンク</h2>


### PR DESCRIPTION
## Summary
- remove the static device preview card section from the home page to keep only admin-linked content

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942a3996f688321b4b3f1d73ec77abd)