### PR TITLE
Add homepage link management and article comments

### DIFF
--- a/public/assets/base.css
+++ b/public/assets/base.css
@@ -194,6 +194,24 @@ header.site-header {
   scrollbar-color: var(--border) transparent;
 }
 
+.scroll-shell {
+  position: relative;
+  display: grid;
+  gap: 10px;
+}
+
+.scroll-controls {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: flex;
+  gap: 6px;
+  background: linear-gradient(135deg, rgba(0,0,0,0.7), rgba(0,0,0,0.3));
+  padding: 6px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+}
+
 .scroll-row::-webkit-scrollbar { height: 10px; }
 .scroll-row::-webkit-scrollbar-track { background: transparent; }
 .scroll-row::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.12); border-radius: 999px; }

--- a/public/assets/blog-data.js
+++ b/public/assets/blog-data.js
@@ -3,6 +3,8 @@
   const settingsKey = "emperor_article_settings";
   const copyKey = "emperor_article_copy";
   const copyExtrasKey = "emperor_article_copy_extras";
+  const pageLinksKey = "emperor_page_links";
+  const commentsKey = "emperor_article_comments_v1";
   const officialLineAccountId = "@projecte_official";
   const baseArticles = [
     {
@@ -102,6 +104,45 @@
     tagSubtitle: "使用頻度順に表示",
   };
 
+  const defaultPageLinks = [
+    {
+      id: "draw",
+      title: "🎨 Draw Board",
+      description: "新しいダークテーマとレスポンシブボタンで描画ツールも刷新。指でもマウスでも快適です。",
+      url: "/draw.html",
+    },
+    {
+      id: "admin",
+      title: "🗂️ 管理ビュー",
+      description: "ログイン後のナビゲーション、認証エラー表示を更新し、リダイレクト導線も整理しました。",
+      url: "/admin.html",
+    },
+    {
+      id: "blog-list",
+      title: "📑 Blog (一覧)",
+      description: "スマホ1カラム、タブレット2カラム、PC2カラム＋サイドバー。新しい統計ウィジェット付き。",
+      url: "/blog-list.html",
+    },
+    {
+      id: "blog-edit",
+      title: "✏️ Blog 編集",
+      description: "フォームとリストを整理し、編集状態やタグ表示を強調。保存後のフィードバックも改善。",
+      url: "/blog-edit.html",
+    },
+    {
+      id: "chat-toc",
+      title: "💬 Chat TOC Maker",
+      description: "チャットの目次生成ツールを新レイアウトに刷新。レスポンシブでシンプルな入力に。",
+      url: "/chat-toc.html",
+    },
+    {
+      id: "article",
+      title: "📰 記事ビュー",
+      description: "個別記事ページは本文とタグ、共有ボタンを再配置。読みやすさを優先した新デザインです。",
+      url: "/blog-article.html",
+    },
+  ];
+
   function loadCopy() {
     const saved = localStorage.getItem(copyKey);
     if (!saved) return { ...defaultCopy };
@@ -119,6 +160,74 @@
     const normalized = { ...defaultCopy, ...copy };
     localStorage.setItem(copyKey, JSON.stringify(normalized));
     return normalized;
+  }
+
+  function normalizePageLinks(list) {
+    const source = Array.isArray(list) ? list : [];
+    const normalized = source
+      .map((item, index) => {
+        const fallbackId = item?.id || `link-${index}`;
+        if (!item?.title || !item?.url) return null;
+        return {
+          id: String(fallbackId),
+          title: String(item.title),
+          description: item.description ? String(item.description) : "",
+          url: String(item.url),
+        };
+      })
+      .filter(Boolean);
+    if (!Array.isArray(list)) return [...defaultPageLinks];
+    return normalized;
+  }
+
+  function loadPageLinks() {
+    const saved = localStorage.getItem(pageLinksKey);
+    if (!saved) return [...defaultPageLinks];
+    try {
+      const parsed = JSON.parse(saved);
+      return normalizePageLinks(parsed);
+    } catch (err) {
+      console.warn("Failed to parse page links", err);
+      return [...defaultPageLinks];
+    }
+  }
+
+  function savePageLinks(list) {
+    const normalized = normalizePageLinks(list);
+    localStorage.setItem(pageLinksKey, JSON.stringify(normalized));
+    return normalized;
+  }
+
+  function loadCommentsMap() {
+    try {
+      const saved = JSON.parse(localStorage.getItem(commentsKey));
+      return saved && typeof saved === "object" ? saved : {};
+    } catch (err) {
+      console.warn("Failed to parse comments", err);
+      return {};
+    }
+  }
+
+  function loadComments(articleId) {
+    const map = loadCommentsMap();
+    return Array.isArray(map?.[articleId]) ? map[articleId] : [];
+  }
+
+  function addComment(articleId, payload) {
+    if (!articleId && articleId !== 0) return loadComments(articleId);
+    const map = loadCommentsMap();
+    const list = Array.isArray(map[articleId]) ? map[articleId] : [];
+    const newComment = {
+      id: crypto.randomUUID?.() ?? `c-${Date.now()}`,
+      author: payload?.author?.trim() || "名無しさん",
+      body: payload?.body?.trim() || "",
+      createdAt: Date.now(),
+    };
+    if (!newComment.body) return list;
+    const next = [newComment, ...list].slice(0, 100);
+    map[articleId] = next;
+    localStorage.setItem(commentsKey, JSON.stringify(map));
+    return next;
   }
 
   function loadCopyExtras() {
@@ -219,9 +328,12 @@
     settingsKey,
     copyKey,
     copyExtrasKey,
+    pageLinksKey,
+    commentsKey,
     officialLineAccountId,
     baseArticles,
     defaultCopy,
+    defaultPageLinks,
     loadArticles,
     saveArticles,
     loadSettings,
@@ -230,6 +342,8 @@
     saveCopy,
     loadCopyExtras,
     saveCopyExtras,
+    loadPageLinks,
+    savePageLinks,
     upsertArticle,
     deleteArticle,
     findArticle,
@@ -239,5 +353,7 @@
     getHomeLatestArticles,
     getHomeFeaturedArticles,
     buildOfficialLineShare,
+    loadComments,
+    addComment,
   };
 })();

--- a/public/assets/blog-shared.css
+++ b/public/assets/blog-shared.css
@@ -84,6 +84,10 @@ header.site-header {
 .ticker-track { display: flex; gap: 10px; animation: marquee 26s linear infinite; }
 .chip { padding: 7px 12px; border-radius: 999px; border: 1px solid var(--border); background: #0d0d0d; color: var(--muted); white-space: nowrap; }
 
+.comment-card { gap: 6px; }
+.comment-header { display: flex; justify-content: space-between; align-items: center; gap: 10px; }
+.comment-body { margin: 0; color: var(--text); line-height: 1.6; }
+
 @keyframes marquee { 0% { transform: translateX(0); } 100% { transform: translateX(-50%); } }
 
 @media (min-width: 720px) { .scroll-track { grid-auto-columns: 64%; } }

--- a/public/blog-article.html
+++ b/public/blog-article.html
@@ -47,6 +47,30 @@
         </div>
       </aside>
     </section>
+
+    <section class="panel stack" id="commentSection">
+      <div class="section-title">
+        <h3>コメント</h3>
+        <span class="tiny" id="commentStatus">記事への感想を残せます。</span>
+      </div>
+      <form class="stack" id="commentForm">
+        <div class="grid-2" style="gap:12px;">
+          <div class="form-row">
+            <label class="tiny" for="commentAuthor">名前</label>
+            <input id="commentAuthor" name="commentAuthor" placeholder="匿名でも投稿できます">
+          </div>
+          <div class="form-row">
+            <label class="tiny" for="commentBody">コメント</label>
+            <textarea id="commentBody" name="commentBody" rows="3" required placeholder="本文への感想や質問"></textarea>
+          </div>
+        </div>
+        <div class="actions" style="justify-content: space-between; align-items: center; flex-wrap: wrap;">
+          <button class="primary" type="submit">投稿する</button>
+          <span class="tiny">ローカルに保存されるため即時表示されます。</span>
+        </div>
+      </form>
+      <div class="stack" id="commentList" style="gap:10px;"></div>
+    </section>
   </main>
 
 <script src="/assets/lightbox.js"></script>
@@ -55,6 +79,11 @@
   const params = new URLSearchParams(location.search);
   const articleIdx = parseInt(params.get("id"), 10) || 0;
   const { article } = BlogData.findArticle(articleIdx);
+  const commentForm = document.getElementById("commentForm");
+  const commentAuthor = document.getElementById("commentAuthor");
+  const commentBody = document.getElementById("commentBody");
+  const commentList = document.getElementById("commentList");
+  const commentStatus = document.getElementById("commentStatus");
 
   function renderArticle() {
     const hero = document.getElementById("articleHero");
@@ -63,28 +92,28 @@
     const bodyEl = document.getElementById("articleBody");
     const shareRow = document.getElementById("shareRow");
     const meta = document.getElementById("articleMeta");
+    const safeArticle = article || { title: "記事がありません", body: "管理ページから追加してください", tags: [] };
 
-    titleEl.textContent = article.title || "無題の記事";
-    leadEl.textContent = article.body?.slice(0, 120) || "本文を入力してください";
+    titleEl.textContent = safeArticle.title || "無題の記事";
+    leadEl.textContent = safeArticle.body?.slice(0, 120) || "本文を入力してください";
 
     meta.innerHTML = `
       <span class="badge">ID ${articleIdx}</span>
       <span class="badge">レスポンシブ本文</span>
-      ${(article.tags || []).map(tag => `<a class=\"tag\" href=\"/tag.html?tag=${encodeURIComponent(tag)}\">#${tag}</a>`).join(""
-      )}
+      ${(safeArticle.tags || []).map(tag => `<a class=\"tag\" href=\"/tag.html?tag=${encodeURIComponent(tag)}\">#${tag}</a>`).join("")}
     `;
 
-    if (article.image) {
+    if (safeArticle.image) {
       const img = document.createElement("img");
-      img.src = article.image;
-      img.alt = article.title;
+      img.src = safeArticle.image;
+      img.alt = safeArticle.title;
       img.className = "hero-img";
       hero.appendChild(img);
       Lightbox.enhanceImages(hero);
     }
 
     bodyEl.classList.add("article-body");
-    bodyEl.innerHTML = (article.body || "本文がありません").split(/\n+/).map(p => `<p>${p}</p>`).join("");
+    bodyEl.innerHTML = (safeArticle.body || "本文がありません").split(/\n+/).map(p => `<p>${p}</p>`).join("");
 
     const articleUrl = `${location.origin}/blog-article.html?id=${articleIdx}`;
     const shareUrl = BlogData.buildOfficialLineShare(articleUrl);
@@ -94,7 +123,63 @@
     `;
   }
 
-  document.addEventListener("DOMContentLoaded", renderArticle);
+  function formatRelativeTime(timestamp) {
+    const diffMs = Date.now() - timestamp;
+    const diffMinutes = Math.floor(diffMs / 60000);
+    if (diffMinutes < 60) return `${diffMinutes || 1}分前`;
+    const diffHours = Math.floor(diffMinutes / 60);
+    if (diffHours < 24) return `${diffHours}時間前`;
+    const diffDays = Math.floor(diffHours / 24);
+    return `${diffDays}日前`;
+  }
+
+  function renderComments() {
+    const comments = BlogData.loadComments(articleIdx);
+    commentList.innerHTML = "";
+    if (!comments.length) {
+      commentList.innerHTML = '<p class="muted">まだコメントがありません。最初の感想を投稿してください。</p>';
+      return;
+    }
+    comments.forEach((item) => {
+      const row = document.createElement("article");
+      row.className = "card comment-card";
+      const header = document.createElement("div");
+      header.className = "comment-header";
+      const author = document.createElement("strong");
+      author.textContent = item.author || "名無しさん";
+      const time = document.createElement("span");
+      time.className = "tiny";
+      time.textContent = formatRelativeTime(item.createdAt);
+      header.appendChild(author);
+      header.appendChild(time);
+      const body = document.createElement("p");
+      body.className = "comment-body";
+      body.textContent = item.body;
+      row.appendChild(header);
+      row.appendChild(body);
+      commentList.appendChild(row);
+    });
+  }
+
+  function handleCommentSubmit(event) {
+    event.preventDefault();
+    const author = commentAuthor.value.trim();
+    const body = commentBody.value.trim();
+    if (!body) {
+      commentStatus.textContent = "コメントを入力してください。";
+      return;
+    }
+    const next = BlogData.addComment(articleIdx, { author, body });
+    commentBody.value = "";
+    commentStatus.textContent = `${next.length}件のコメント`;
+    renderComments();
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    renderArticle();
+    renderComments();
+  });
+  commentForm.addEventListener("submit", handleCommentSubmit);
 </script>
 </body>
 </html>

--- a/public/blog-edit.html
+++ b/public/blog-edit.html
@@ -153,6 +153,37 @@
     </section>
 
     <section class="panel stack">
+      <div class="section-title">
+        <h3>ページリンク管理</h3>
+        <span class="tiny">トップページのリンクカードを編集・削除</span>
+      </div>
+      <form class="stack" id="pageLinkForm">
+        <div class="grid-2" style="gap:12px;">
+          <div class="form-row">
+            <label class="tiny" for="pageLinkTitle">タイトル（絵文字含め可）</label>
+            <input id="pageLinkTitle" name="pageLinkTitle" required placeholder="📰 記事ビュー">
+          </div>
+          <div class="form-row">
+            <label class="tiny" for="pageLinkUrl">URL</label>
+            <input id="pageLinkUrl" name="pageLinkUrl" required placeholder="/blog-article.html">
+          </div>
+        </div>
+        <div class="form-row">
+          <label class="tiny" for="pageLinkDescription">説明</label>
+          <textarea id="pageLinkDescription" name="pageLinkDescription" rows="3" placeholder="リンク先の補足"></textarea>
+        </div>
+        <div class="actions" style="justify-content: space-between; align-items: center; flex-wrap: wrap;">
+          <div class="flex" style="gap:8px;">
+            <button class="primary" type="submit" id="pageLinkSave">保存</button>
+            <button class="secondary" type="button" id="pageLinkReset">新規追加に切替</button>
+          </div>
+          <span class="tiny" id="pageLinkStatus">トップページのカードに反映されます。</span>
+        </div>
+      </form>
+      <div class="stack" id="pageLinkList" style="gap:10px;"></div>
+    </section>
+
+    <section class="panel stack">
       <form class="stack" id="editorForm">
         <div class="form-row">
           <label for="title" class="tiny">タイトル</label>
@@ -228,6 +259,14 @@
   const copySourceSelect = document.getElementById("copySourceSelect");
   const copySourceStatus = document.getElementById("copySourceStatus");
   const applyCopySourceBtn = document.getElementById("applyCopySource");
+  const pageLinkForm = document.getElementById("pageLinkForm");
+  const pageLinkTitle = document.getElementById("pageLinkTitle");
+  const pageLinkUrl = document.getElementById("pageLinkUrl");
+  const pageLinkDescription = document.getElementById("pageLinkDescription");
+  const pageLinkStatus = document.getElementById("pageLinkStatus");
+  const pageLinkList = document.getElementById("pageLinkList");
+  const pageLinkReset = document.getElementById("pageLinkReset");
+  let editingLinkId = null;
   let editingIdx = null;
   let imageData = "";
 
@@ -492,6 +531,84 @@
     renderCopyExtras();
   }
 
+  function resetPageLinkForm(link = {}) {
+    pageLinkTitle.value = link.title || "";
+    pageLinkUrl.value = link.url || "";
+    pageLinkDescription.value = link.description || "";
+    editingLinkId = link.id ?? null;
+    pageLinkStatus.textContent = editingLinkId ? `ID ${editingLinkId} を編集中です。` : "トップページのカードに反映されます。";
+  }
+
+  function renderPageLinks() {
+    const links = BlogData.loadPageLinks();
+    pageLinkList.innerHTML = "";
+    if (!links.length) {
+      pageLinkList.innerHTML = '<p class="muted">リンクがありません。追加してください。</p>';
+      return;
+    }
+    links.forEach((link) => {
+      const row = document.createElement("article");
+      row.className = "card";
+      row.innerHTML = `
+        <div class="actions" style="justify-content: space-between; align-items: flex-start; flex-wrap: wrap;">
+          <div class="stack" style="gap:6px;">
+            <div class="inline-chips">
+              <span class="badge">ID ${link.id}</span>
+              <span class="badge">${link.url}</span>
+            </div>
+            <h3 style="margin:0;">${link.title}</h3>
+            <p class="muted" style="margin:0;">${link.description || ""}</p>
+          </div>
+          <div class="stack" style="gap:6px; align-items:flex-end;">
+            <button class="secondary" data-action="edit-link" data-id="${link.id}">編集</button>
+            <button class="secondary" data-action="delete-link" data-id="${link.id}">削除</button>
+          </div>
+        </div>
+      `;
+      pageLinkList.appendChild(row);
+    });
+  }
+
+  function handlePageLinkSave(event) {
+    event.preventDefault();
+    const title = pageLinkTitle.value.trim();
+    const url = pageLinkUrl.value.trim();
+    const description = pageLinkDescription.value.trim();
+    if (!title || !url) {
+      pageLinkStatus.textContent = "タイトルとURLは必須です。";
+      return;
+    }
+    const links = BlogData.loadPageLinks();
+    const id = editingLinkId ?? `link-${Date.now()}`;
+    const next = links.filter((item) => item.id !== id);
+    next.unshift({ id, title, url, description });
+    const saved = BlogData.savePageLinks(next);
+    renderPageLinks();
+    resetPageLinkForm();
+    pageLinkStatus.textContent = `${saved.length}件のリンクを保存しました。`;
+  }
+
+  function handlePageLinkListClick(event) {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    const { action, id } = target.dataset;
+    if (!id) return;
+    const links = BlogData.loadPageLinks();
+    if (action === "edit-link") {
+      const link = links.find((item) => item.id === id);
+      if (link) {
+        resetPageLinkForm(link);
+      }
+    }
+    if (action === "delete-link") {
+      const next = links.filter((item) => item.id !== id);
+      BlogData.savePageLinks(next);
+      renderPageLinks();
+      resetPageLinkForm();
+      pageLinkStatus.textContent = `ID ${id} を削除しました。`;
+    }
+  }
+
   function attachSwipeHandler(element, onCommit) {
     const body = element.querySelector(".swipe-body");
     let startX = 0;
@@ -662,6 +779,8 @@
     renderSettingsForm();
     renderCopyForm();
     renderCopyExtras();
+    renderPageLinks();
+    resetPageLinkForm();
   });
 
   form.addEventListener("submit", handleSave);
@@ -685,6 +804,9 @@
     }
   });
   applyCopySourceBtn.addEventListener("click", applyCopySource);
+  pageLinkForm.addEventListener("submit", handlePageLinkSave);
+  pageLinkReset.addEventListener("click", () => resetPageLinkForm());
+  pageLinkList.addEventListener("click", handlePageLinkListClick);
 </script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -40,7 +40,13 @@
         <h2>注目記事</h2>
         <span class="muted">横スクロールでチェック</span>
       </div>
-      <div class="scroll-row" id="featuredRow"></div>
+      <div class="scroll-shell">
+        <div class="scroll-row" id="featuredRow"></div>
+        <div class="scroll-controls" aria-hidden="true">
+          <button class="pill ghost" type="button" data-scroll="left">◀</button>
+          <button class="pill ghost" type="button" data-scroll="right">▶</button>
+        </div>
+      </div>
     </section>
 
     <section class="section">
@@ -58,38 +64,7 @@
         <h2>ページリンク</h2>
         <span class="muted">すべてレスポンシブ対応</span>
       </div>
-      <div class="card-grid">
-        <article class="card">
-          <h3>🎨 Draw Board</h3>
-          <p>新しいダークテーマとレスポンシブボタンで描画ツールも刷新。指でもマウスでも快適です。</p>
-          <a class="button primary" href="/draw.html">開く</a>
-        </article>
-        <article class="card">
-          <h3>🗂️ 管理ビュー</h3>
-          <p>ログイン後のナビゲーション、認証エラー表示を更新し、リダイレクト導線も整理しました。</p>
-          <a class="button ghost" href="/admin.html">開く</a>
-        </article>
-        <article class="card">
-          <h3>📑 Blog (一覧)</h3>
-          <p>スマホ1カラム、タブレット2カラム、PC2カラム＋サイドバー。新しい統計ウィジェット付き。</p>
-          <a class="button ghost" href="/blog-list.html">開く</a>
-        </article>
-        <article class="card">
-          <h3>✏️ Blog 編集</h3>
-          <p>フォームとリストを整理し、編集状態やタグ表示を強調。保存後のフィードバックも改善。</p>
-          <a class="button ghost" href="/blog-edit.html">開く</a>
-        </article>
-        <article class="card">
-          <h3>💬 Chat TOC Maker</h3>
-          <p>チャットの目次生成ツールを新レイアウトに刷新。レスポンシブでシンプルな入力に。</p>
-          <a class="button ghost" href="/chat-toc.html">開く</a>
-        </article>
-        <article class="card">
-          <h3>📰 記事ビュー</h3>
-          <p>個別記事ページは本文とタグ、共有ボタンを再配置。読みやすさを優先した新デザインです。</p>
-          <a class="button ghost" href="/blog-article.html">開く</a>
-        </article>
-      </div>
+      <div class="card-grid" id="pageLinks"></div>
     </section>
   </main>
 
@@ -110,6 +85,7 @@
     const heroBadge = document.getElementById("heroBadge");
     const heroMeta = document.getElementById("heroMeta");
     const featuredRow = document.getElementById("featuredRow");
+    const pageLinks = document.getElementById("pageLinks");
 
     const heroFallback = {
       title: "全ページをレスポンシブで作り直しました",
@@ -196,6 +172,37 @@
       });
     }
 
+    function attachHorizontalControls(track) {
+      const controls = track.parentElement?.querySelectorAll('[data-scroll]');
+      if (!controls?.length) return;
+      controls.forEach((btn) => {
+        btn.addEventListener("click", () => {
+          const direction = btn.dataset.scroll === "left" ? -1 : 1;
+          const distance = track.clientWidth * 0.8 * direction;
+          track.scrollBy({ left: distance, behavior: "smooth" });
+        });
+      });
+    }
+
+    function renderPageLinks() {
+      const links = BlogData.loadPageLinks();
+      pageLinks.innerHTML = "";
+      if (!links.length) {
+        pageLinks.innerHTML = '<p class="muted">ページリンクがまだ設定されていません。</p>';
+        return;
+      }
+      links.forEach((link) => {
+        const card = document.createElement("article");
+        card.className = "card";
+        card.innerHTML = `
+          <h3>${link.title}</h3>
+          <p>${link.description || ""}</p>
+          <a class="button ghost" href="${link.url}">開く</a>
+        `;
+        pageLinks.appendChild(card);
+      });
+    }
+
     function renderHeroFromArticle() {
       const { article, idx } = BlogData.getHeroArticle();
       const articles = BlogData.loadArticles();
@@ -251,6 +258,8 @@
       renderHeroFromArticle();
       renderLatestList();
       renderFeaturedRow();
+      renderPageLinks();
+      attachHorizontalControls(featuredRow);
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add horizontal controls for the featured carousel and render homepage page links from managed data
- allow link cards to be created, edited, or removed from the management page
- add local comment posting and display to article pages

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942a92813f48321a29a2f904e1724d5)