### PR TITLE
Rearrange header controls and consolidate aftercare column

### DIFF
--- a/Calcu.html
+++ b/Calcu.html
@@ -31,12 +31,11 @@ td.col-remark, th.col-remark {
 .selection-panel {
   margin-bottom: 8px;
 }
-/* 預り保育セル（右寄せ2列：預り保育 / 預り保育料金） */
-.col-azukari,
-.col-azukarif {
+/* 預り保育セル（分と料金をまとめた1列） */
+.col-azukari {
   text-align: center;
   vertical-align: middle;
-  width: 90px;
+  width: 120px;
 }
 /* 合計（黄色のボックス） */
 .azukari-total {
@@ -75,6 +74,16 @@ td.col-remark, th.col-remark {
 /* ホバー効果 */
 .azukariBtn:hover {
   opacity: 0.85;
+}
+.azukari-fee {
+  font-size: 11px;
+  color: #92400e;
+  background: #fffbeb;
+  border: 1px dashed #f59e0b;
+  border-radius: 6px;
+  padding: 2px 6px;
+  width: fit-content;
+  margin: 0 auto;
 }
 /* 1行（園：〇〇… の1行） */
 .selection-row {
@@ -303,12 +312,14 @@ td.col-remark, th.col-remark {
     header {
       background:linear-gradient(120deg,var(--accent),#38bdf8);
       color:#fff;
-      padding:14px 20px;
+      padding:14px 20px 10px;
       box-shadow:0 2px 12px rgba(0,0,0,0.12);
       display:flex;
-      align-items:center;
-      gap:12px;
-      position:relative;
+      flex-direction:column;
+      gap:8px;
+      position:sticky;
+      top:0;
+      z-index:10;
     }
     .logo-circle {
       width:40px;height:40px;border-radius:50%;
@@ -323,8 +334,36 @@ td.col-remark, th.col-remark {
     header p {
       margin:2px 0 0;font-size:12px;color:rgba(255,255,255,0.9);
     }
+    .header-top {
+      display:flex;
+      align-items:center;
+      gap:12px;
+      width:100%;
+    }
+    .header-info { flex:1; }
+    .header-controls {
+      width:100%;
+      display:grid;
+      grid-template-columns:repeat(auto-fit,minmax(280px,1fr));
+      gap:10px;
+    }
+    .header-card {
+      background:rgba(255,255,255,0.14);
+      border:1px solid rgba(255,255,255,0.32);
+      border-radius:12px;
+      padding:10px;
+      color:#fff;
+      box-shadow:0 4px 14px rgba(0,0,0,0.12);
+    }
+    .header-card h2 {
+      margin:0 0 6px;
+      font-size:15px;
+      color:#fff;
+    }
+    .header-card .muted { color:rgba(255,255,255,0.85); }
+    body.controls-collapsed .header-controls { display:none; }
     .sidebar-toggle {
-      position:absolute;right:20px;top:16px;
+      margin-left:auto;
     }
     /* ===== レイアウト ===== */
     main {
@@ -332,12 +371,10 @@ td.col-remark, th.col-remark {
       max-width:1200px;
       margin:0 auto 80px;
       display:grid;
-      grid-template-columns:minmax(260px,320px) 1fr;
+      grid-template-columns:1fr;
       gap:16px;
       align-items:flex-start;
     }
-    body.sidebar-collapsed main { grid-template-columns:1fr; }
-    body.sidebar-collapsed .sidebar { display:none; }
     .panel {
       background:#fff;
       border:1px solid var(--border);
@@ -730,6 +767,7 @@ tr.row-3gou td {
     .hide-h-buffer  th.col-buffer,  .hide-h-buffer  td.col-buffer  {display:none;}
     .hide-h-arrive  th.col-arrive,  .hide-h-arrive  td.col-arrive  {display:none;}
     .hide-h-leave   th.col-leave,   .hide-h-leave   td.col-leave   {display:none;}
+    .hide-h-azukari th.col-azukari, .hide-h-azukari td.col-azukari {display:none;}
     .hide-h-over    th.col-over,    .hide-h-over    td.col-over    {display:none;}
     .hide-h-extu    th.col-extu,    .hide-h-extu    td.col-extu    {display:none;}
     .hide-h-extf    th.col-extf,    .hide-h-extf    td.col-extf    {display:none;}
@@ -875,7 +913,6 @@ td.col-type {
     @media(max-width:720px){
       header h1{font-size:18px;}
       main{display:block;}
-      .sidebar-toggle{display:none;}
       table{font-size:13px;}
       th,td{padding:6px 4px;}
     }
@@ -964,16 +1001,16 @@ td.col-type {
 </head>
 <body>
   <header>
-    <div class="logo-circle">園</div>
-    <div style="flex:1;">
-      <h1>標準・短時間 切り替え計算</h1>
-      <p>延長保育：30分200円（3,000円上限）／ 登園が早くても延長計算</p>
+    <div class="header-top">
+      <div class="logo-circle">園</div>
+      <div class="header-info">
+        <h1>標準・短時間 切り替え計算</h1>
+        <p>延長保育：30分200円（3,000円上限）／ 登園が早くても延長計算</p>
+      </div>
+      <button id="toggleSidebar" class="small secondary sidebar-toggle">入力・設定を隠す</button>
     </div>
-    <button id="toggleSidebar" class="small secondary sidebar-toggle">サイドバーをとじる</button>
-  </header>
-  <main>
-    <div class="sidebar">
-      <section class="panel">
+    <div class="header-controls" id="headerControls">
+      <div class="header-card">
         <h2>入力</h2>
         <div class="grid two">
           <div>
@@ -994,9 +1031,9 @@ td.col-type {
             </p>
           </div>
         </div>
-      </section>
-      <section class="panel">
-        <h2>出力・表示設定</h2>
+      </div>
+      <div class="header-card">
+        <h2>設定</h2>
         <div style="margin-bottom:10px;display:flex;flex-direction:column;gap:6px;">
           <button id="download"     type="button" class="small secondary" disabled>サマリーExcel風</button>
           <button id="downloadPage" type="button" class="small secondary" disabled>ページHTML保存</button>
@@ -1014,21 +1051,24 @@ td.col-type {
             <label><input type="checkbox" id="hideHeaderBuffer" checked /> バッファ列</label>
             <label><input type="checkbox" id="hideHeaderArrive" /> 登園時刻列</label>
             <label><input type="checkbox" id="hideHeaderLeave" /> 降園時刻列</label>
+            <label><input type="checkbox" id="hideHeaderAzukari" /> 預り保育列</label>
             <label><input type="checkbox" id="hideHeaderOver" /> 延長時間列</label>
             <label><input type="checkbox" id="hideHeaderExtU" checked /> 延長回数列</label>
             <label><input type="checkbox" id="hideHeaderExtF" /> 延長料金列</label>
             <label><input type="checkbox" id="hideHeaderRemark" /> 備考列</label>
           </div>
         </details>
-      </section>
-      <section class="panel">
+      </div>
+      <div class="header-card">
         <h2>変更履歴</h2>
         <details id="logDetails">
           <summary>履歴を表示</summary>
           <div id="logContainer" class="muted" style="margin-top:6px;">まだ変更はありません。</div>
         </details>
-      </section>
+      </div>
     </div>
+  </header>
+  <main>
     <div class="content">
       <section class="panel">
         <h2>月別・人別サマリー</h2>
@@ -1111,6 +1151,7 @@ const END_1GOU       = 16*60+30;  // 1号認定 16:
     const hideHeaderBuffer  = document.getElementById('hideHeaderBuffer');
     const hideHeaderArrive  = document.getElementById('hideHeaderArrive');
     const hideHeaderLeave   = document.getElementById('hideHeaderLeave');
+    const hideHeaderAzukari = document.getElementById('hideHeaderAzukari');
     const hideHeaderOver    = document.getElementById('hideHeaderOver');
     const hideHeaderExtU    = document.getElementById('hideHeaderExtU');
     const hideHeaderExtF    = document.getElementById('hideHeaderExtF');
@@ -1164,13 +1205,15 @@ function makeChildKey(school, clazz, name){
   return [school || '', clazz || '', name || ''].join('|');
 }
     // サイドバー開閉
-    toggleSidebarBtn.addEventListener('click',()=>{
-      document.body.classList.toggle('sidebar-collapsed');
-      const collapsed = document.body.classList.contains('sidebar-collapsed');
-      toggleSidebarBtn.textContent = collapsed
-        ? 'サイドバーをひらく'
-        : 'サイドバーをとじる';
-    });
+    if (toggleSidebarBtn) {
+      toggleSidebarBtn.addEventListener('click',()=>{
+        document.body.classList.toggle('controls-collapsed');
+        const collapsed = document.body.classList.contains('controls-collapsed');
+        toggleSidebarBtn.textContent = collapsed
+          ? '入力・設定を表示'
+          : '入力・設定を隠す';
+      });
+    }
     // CSVヘルプ
     helpCsvBtn.addEventListener('click',()=>{helpModal.style.display='flex';});
     helpClose.addEventListener('click',()=>{helpModal.style.display='none';});
@@ -1191,6 +1234,7 @@ function makeChildKey(school, clazz, name){
         'hide-h-buffer',
         'hide-h-arrive',
         'hide-h-leave',
+        'hide-h-azukari',
         'hide-h-over',
         'hide-h-extu',
         'hide-h-extf',
@@ -1207,6 +1251,7 @@ function makeChildKey(school, clazz, name){
         [hideHeaderBuffer, 'hide-h-buffer'],
         [hideHeaderArrive, 'hide-h-arrive'],
         [hideHeaderLeave,  'hide-h-leave'],
+        [hideHeaderAzukari,'hide-h-azukari'],
         [hideHeaderOver,   'hide-h-over'],
         [hideHeaderExtU,   'hide-h-extu'],
         [hideHeaderExtF,   'hide-h-extf'],
@@ -1237,6 +1282,7 @@ function makeChildKey(school, clazz, name){
       hideHeaderBuffer,
       hideHeaderArrive,
       hideHeaderLeave,
+      hideHeaderAzukari,
       hideHeaderOver,
       hideHeaderExtU,
       hideHeaderExtF,
@@ -1953,13 +1999,12 @@ const rowsHtml = list.map(item=>{
             '<button type="button" class="azukariBtn minus" data-index="'+item.recordIndex+'" data-delta="-15">-15分</button>'+
             '<button type="button" class="azukariBtn plus"  data-index="'+item.recordIndex+'" data-delta="15">+15分</button>'+
           '</div>'+
+          '<div class="azukari-fee">料金 '+azukariFee.toLocaleString()+'円</div>'+
         '</div>'+
       '</td>'+
       '<td class="col-over">'+overText+'</td>'+
       '<td class="col-extu">'+item.extUnits+'</td>'+
       '<td class="col-extf">'+extText+'</td>'+
-      // ★ 預り保育料金（将来計算に使う：今は 0 でもOK）
-      '<td class="col-azukarif">'+azukariFee+'円</td>'+
       '<td class="col-totalf">'+totalText+'</td>'+
       '<td class="col-remark">'+remarkHtml+'</td>'+
     '</tr>'
@@ -1996,8 +2041,6 @@ const rowsHtml = list.map(item=>{
   '<th class="col-over">延長時間(分)</th>'+
   '<th class="col-extu">延長回数</th>'+
   '<th class="col-extf">延長保育料金</th>'+
-  // ★ 新列：預り保育料金
-  '<th class="col-azukarif">預り保育料金</th>'+
   '<th class="col-totalf">合計料金</th>'+
   '<th class="col-remark">備考</th>'+
 '</tr></thead>'+


### PR DESCRIPTION
## Summary
- Move file input, buffer, and display settings into sticky header cards with a show/hide toggle
- Consolidate the aftercare display into a single column with grouped minutes and fee information plus a visibility toggle
- Keep change log access in the header alongside other controls to reduce scrolling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943ce17c9c083219776b2208f87cfed)