### PR TITLE
Add homepage slider and backups

### DIFF
--- a/public/assets/base.css
+++ b/public/assets/base.css
@@ -247,6 +247,45 @@ header.site-header {
 .featured-card h3 { margin: 0; font-size: 18px; letter-spacing: 0.01em; }
 .featured-card p { margin: 0; color: var(--muted); line-height: 1.6; }
 
+.feature-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: linear-gradient(145deg, rgba(255,255,255,0.02), rgba(0,0,0,0.4));
+  box-shadow: 0 12px 32px rgba(0,0,0,0.32);
+  scroll-snap-align: start;
+  min-height: 100%;
+}
+
+.feature-thumb {
+  width: 100%;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  background: #0b0b0b;
+}
+
+.feature-body {
+  display: grid;
+  gap: 8px;
+  flex: 1;
+}
+
+.feature-meta {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.feature-row { grid-auto-columns: minmax(300px, 1fr); }
+
 .featured-pill {
   width: fit-content;
   padding: 6px 10px;
@@ -399,9 +438,14 @@ textarea { resize: vertical; min-height: 140px; }
     gap: 14px;
     padding: 16px;
     background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));
+    grid-auto-rows: 1fr;
+    align-items: stretch;
   }
 
   .list.card-layout .list-card {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
     border: 1px solid var(--border);
     border-radius: var(--radius);
     background: linear-gradient(145deg, rgba(255,255,255,0.02), rgba(0,0,0,0.35));
@@ -414,6 +458,17 @@ textarea { resize: vertical; min-height: 140px; }
     transform: translateY(-4px);
     box-shadow: 0 22px 54px rgba(0, 0, 0, 0.48);
     background: linear-gradient(145deg, rgba(255,255,255,0.04), rgba(0,0,0,0.42));
+  }
+
+  .list.card-layout .list-card .stack {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .list.card-layout .list-card .actions {
+    margin-top: auto;
   }
 
   .list.card-layout .actions {

--- a/public/blog-edit.html
+++ b/public/blog-edit.html
@@ -80,6 +80,29 @@
     </section>
 
     <section class="panel stack">
+      <div class="section-title" style="align-items: flex-end;">
+        <div>
+          <h3>バックアップ / 復元</h3>
+          <p class="tiny" style="margin:4px 0 0;">JSONを保存・復元して、アップデート後も記事や設定を残せます。</p>
+        </div>
+        <div class="inline-chips">
+          <span class="badge">記事・設定・リンク・コメント</span>
+          <span class="badge">ローカル保存 + JSON</span>
+        </div>
+      </div>
+      <div class="flex" style="gap:10px; flex-wrap: wrap; align-items: center;">
+        <button class="primary" type="button" id="backupExport">バックアップを作成</button>
+        <button class="secondary" type="button" id="backupImport">JSONを復元</button>
+        <label class="pill ghost" style="cursor:pointer; gap:6px; align-items:center;">
+          ファイルを読み込む
+          <input id="backupFile" type="file" accept="application/json" style="display:none;">
+        </label>
+        <span class="tiny" id="backupStatus">ローカルにも自動保存されます。</span>
+      </div>
+      <textarea id="backupTextarea" rows="8" style="width:100%; background:#050505; color:var(--text); border:1px solid var(--border); border-radius: var(--radius); padding:10px; font-family: ui-monospace, SFMono-Regular, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;"></textarea>
+    </section>
+
+    <section class="panel stack">
       <div class="section-title">
         <h3>文言設定</h3>
         <span class="tiny">一覧ページの各項目テキストを変更</span>
@@ -266,6 +289,11 @@
   const pageLinkStatus = document.getElementById("pageLinkStatus");
   const pageLinkList = document.getElementById("pageLinkList");
   const pageLinkReset = document.getElementById("pageLinkReset");
+  const backupTextarea = document.getElementById("backupTextarea");
+  const backupStatus = document.getElementById("backupStatus");
+  const backupExportBtn = document.getElementById("backupExport");
+  const backupImportBtn = document.getElementById("backupImport");
+  const backupFileInput = document.getElementById("backupFile");
   let editingLinkId = null;
   let editingIdx = null;
   let imageData = "";
@@ -529,6 +557,40 @@
     copyExtraInput.value = "";
     copyExtraStatus.textContent = `${next.length}件の文言を保存しました。`;
     renderCopyExtras();
+  }
+
+  function refreshBackupTextarea() {
+    const snapshot = BlogData.exportState();
+    backupTextarea.value = JSON.stringify(snapshot, null, 2);
+    const date = new Date(snapshot.exportedAt);
+    backupStatus.textContent = `記事 ${snapshot.articles.length} 件を ${date.toLocaleString()} にバックアップしました。`;
+  }
+
+  function handleBackupImport(event) {
+    event?.preventDefault?.();
+    try {
+      const parsed = JSON.parse(backupTextarea.value || "{}");
+      const result = BlogData.importState(parsed);
+      backupStatus.textContent = `記事 ${result.articles.length} 件を復元しました。`;
+      renderList();
+      renderSettingsForm();
+      renderCopyForm();
+      renderCopyExtras();
+      renderPageLinks();
+    } catch (err) {
+      backupStatus.textContent = err?.message || "JSONの解析に失敗しました。";
+    }
+  }
+
+  function handleBackupFile(event) {
+    const [file] = event.target.files || [];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      backupTextarea.value = reader.result;
+      backupStatus.textContent = `${file.name} を読み込みました。JSONを復元ボタンで適用してください。`;
+    };
+    reader.readAsText(file);
   }
 
   function resetPageLinkForm(link = {}) {
@@ -803,6 +865,7 @@
     renderCopyExtras();
     renderPageLinks();
     resetPageLinkForm();
+    refreshBackupTextarea();
   });
 
   form.addEventListener("submit", handleSave);
@@ -829,6 +892,9 @@
   pageLinkForm.addEventListener("submit", handlePageLinkSave);
   pageLinkReset.addEventListener("click", () => resetPageLinkForm());
   pageLinkList.addEventListener("click", handlePageLinkListClick);
+  backupExportBtn.addEventListener("click", refreshBackupTextarea);
+  backupImportBtn.addEventListener("click", handleBackupImport);
+  backupFileInput.addEventListener("change", handleBackupFile);
 </script>
 
 <script>

--- a/public/index.html
+++ b/public/index.html
@@ -3,15 +3,241 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Emperor News</title>
-<body style="font:16px/1.6 system-ui;margin:40px;max-width:800px">
-  <h1>Emperor News</h1>
-  <p>Welcome to <strong>emperor.news</strong> — deployed from <em>project-E</em>.</p>
-  <p><a href="/draw.html">🎨 Go to Draw Board</a></p>
-  <p>Status check: <a href="/health.txt">health.txt</a></p>
-<p><a href="/draw.html">Go to Draw Board</a></p>
-<p><a href="/chat-toc.html">Go to Chat TOC Maker</a></p>
-<p><a href="/blog.html">📱 Mobile Blog Experience</a> — animated iPhone/iPad scroll view with LINE sharing</p>
-<p><a href="/blog-public.html">📰 Public News Page</a> — black minimal reading view for readers + official LINE sharing</p>
+<link rel="stylesheet" href="/assets/base.css">
+<body>
+  <header class="site-header">
+    <div class="brand">
+      <div class="logo">E</div>
+      <div>
+        <h1>Emperor News</h1>
+        <p>トップページ / ハイライト &amp; 横スライド特集</p>
+      </div>
+    </div>
+    <div class="actions">
+      <a class="pill" href="/blog-list.html">ブログ一覧</a>
+      <a class="pill ghost" href="/blog-edit.html" data-requires-auth="true">管理ページ</a>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="hero home-hero" id="heroSection">
+      <div class="inline-chips">
+        <span class="badge">トップハイライト</span>
+        <span class="badge" id="heroMeta">読み込み中...</span>
+      </div>
+      <div class="grid-2" style="align-items:center;">
+        <div class="stack" style="gap:12px;">
+          <h2 id="heroTitle">Emperor News</h2>
+          <p class="muted" id="heroBody">記事データを読み込み中です。</p>
+          <div class="actions" id="heroActions"></div>
+        </div>
+        <div id="heroVisual"></div>
+      </div>
+    </section>
+
+    <section class="panel stack" id="featureSection">
+      <div class="section-title">
+        <h3>横スライド特集</h3>
+        <span class="tiny">管理ページで選択した記事をスライド表示</span>
+      </div>
+      <div class="scroll-row feature-row" id="featureRow"></div>
+      <p class="tiny muted" id="featureHint">トップページの特集枠です。管理ページの「トップページの注目記事」から設定できます。</p>
+    </section>
+
+    <section class="panel stack latest-list" id="latestSection">
+      <div class="section-title">
+        <h3>最新ピックアップ</h3>
+        <span class="tiny">トップ用に並べる最新記事 (最大4件)</span>
+      </div>
+      <div class="list card-layout" id="latestList"></div>
+    </section>
+
+    <section class="panel stack" id="linksSection">
+      <div class="section-title">
+        <h3>その他のリンク</h3>
+        <span class="tiny">記事以外のツールやビュー</span>
+      </div>
+      <div class="card-grid" id="pageLinks"></div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="actions" style="justify-content: space-between; flex-wrap: wrap; gap:12px;">
+      <span class="tiny">© Emperor News — ローカル保存に対応しています。</span>
+      <div class="actions" style="gap:8px;">
+        <a class="pill" href="/admin.html">管理者ログイン</a>
+        <a class="pill ghost" href="/blog-public.html">読者ビュー</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="/assets/lightbox.js"></script>
+  <script src="/assets/blog-data.js"></script>
+  <script>
+    const adminSessionKey = "emperor_admin_token";
+    const heroMeta = document.getElementById("heroMeta");
+    const heroTitle = document.getElementById("heroTitle");
+    const heroBody = document.getElementById("heroBody");
+    const heroActions = document.getElementById("heroActions");
+    const heroVisual = document.getElementById("heroVisual");
+    const featureSection = document.getElementById("featureSection");
+    const featureRow = document.getElementById("featureRow");
+    const featureHint = document.getElementById("featureHint");
+    const latestList = document.getElementById("latestList");
+    const latestSection = document.getElementById("latestSection");
+    const pageLinks = document.getElementById("pageLinks");
+
+    function enforceAdminLinks() {
+      const adminLinks = document.querySelectorAll('[data-requires-auth]');
+      adminLinks.forEach((link) => {
+        link.addEventListener("click", (event) => {
+          const authed = sessionStorage.getItem(adminSessionKey) === "active";
+          if (authed) return;
+          event.preventDefault();
+          const target = link.getAttribute("href") || "/blog-edit.html";
+          const redirect = encodeURIComponent(target.startsWith("/") ? target : `/${target}`);
+          location.href = `/admin.html?redirect=${redirect}`;
+        });
+      });
+    }
+
+    function formatRelativeHours(idx) {
+      const base = Date.now() - idx * 3_600_000 * 2;
+      const diffHours = Math.max(1, Math.round((Date.now() - base) / 3_600_000));
+      if (diffHours < 24) return `${diffHours}時間前`;
+      const days = Math.round(diffHours / 24);
+      return `${days}日前`;
+    }
+
+    function renderHero(articles) {
+      const { article, idx } = BlogData.getHeroArticle();
+      const target = article ?? articles[0];
+      if (!target) {
+        heroTitle.textContent = "記事がありません";
+        heroBody.textContent = "管理ページから記事を追加してください。";
+        heroMeta.textContent = "未設定";
+        heroActions.innerHTML = '<a class="pill" href="/blog-edit.html">記事を追加</a>';
+        heroVisual.innerHTML = '<div class="thumb fallback" style="max-width:360px;">NO IMAGE</div>';
+        return;
+      }
+      const heroIdx = Number.isInteger(idx) ? idx : 0;
+      heroMeta.textContent = `ID ${heroIdx} / ${formatRelativeHours(heroIdx)}に更新`;
+      heroTitle.textContent = target.title || "無題の記事";
+      heroBody.textContent = target.body || "本文がありません";
+      heroActions.innerHTML = `
+        <a class="share line" href="${BlogData.buildOfficialLineShare(`${location.origin}/blog-article.html?id=${heroIdx}`)}" target="_blank" rel="noreferrer">LINEで共有</a>
+        <a class="share" href="/blog-article.html?id=${heroIdx}">記事を開く</a>
+      `;
+      if (target.image) {
+        heroVisual.innerHTML = `<img class="thumb" src="${target.image}" alt="${target.title}">`;
+        Lightbox.enhanceImages(heroVisual);
+      } else {
+        heroVisual.innerHTML = '<div class="thumb fallback" style="max-width:360px;">NO IMAGE</div>';
+      }
+    }
+
+    function renderFeatured(articles) {
+      featureRow.innerHTML = "";
+      const { list } = BlogData.getHomeFeaturedArticles();
+      const source = list.length ? list : articles.slice(0, 4).map((article, idx) => ({ article, idx }));
+      if (!source.length) {
+        featureSection.style.display = "none";
+        return new Set();
+      }
+      featureSection.style.display = "grid";
+      source.forEach(({ article, idx }) => {
+        const card = document.createElement("article");
+        card.className = "feature-card";
+        card.innerHTML = `
+          ${article.image ? `<img class="feature-thumb" src="${article.image}" alt="${article.title}">` : '<div class="thumb fallback" style="aspect-ratio:4/3;">NO IMAGE</div>'}
+          <div class="feature-body">
+            <div class="feature-meta">
+              <span class="badge">ID ${idx}</span>
+              <span class="badge">${formatRelativeHours(idx)}更新</span>
+            </div>
+            <h3 style="margin:0; font-size:18px; letter-spacing:0.01em;">${article.title || "無題の記事"}</h3>
+            <p class="muted" style="margin:0;">${article.body || "本文がありません"}</p>
+            <div class="tag-row">${(article.tags || []).map(tag => `<span class="tag">#${tag}</span>`).join("") || '<span class="tag">#untagged</span>'}</div>
+            <div class="actions" style="justify-content:flex-end;">
+              <a class="share" href="/blog-article.html?id=${idx}" target="_blank">読む</a>
+            </div>
+          </div>
+        `;
+        featureRow.appendChild(card);
+      });
+      featureHint.textContent = `${source.length}件の特集を表示中です。管理ページから並び順を変えられます。`;
+      Lightbox.enhanceImages(featureRow);
+      return new Set(source.map((item) => item.idx));
+    }
+
+    function renderLatest(articles, excludeIds = new Set()) {
+      latestList.innerHTML = "";
+      const { list } = BlogData.getHomeLatestArticles();
+      const selected = list.length ? list : articles.map((article, idx) => ({ article, idx }));
+      const filtered = selected.filter(({ idx }) => !excludeIds.has(idx)).slice(0, 4);
+      if (!filtered.length) {
+        latestSection.style.display = "none";
+        return;
+      }
+      latestSection.style.display = "grid";
+      filtered.forEach(({ article, idx }) => {
+        const card = document.createElement("article");
+        card.className = "list-card";
+        card.innerHTML = `
+          ${article.image ? `<img class="thumb" src="${article.image}" alt="${article.title}">` : '<div class="thumb fallback">NO IMAGE</div>'}
+          <div class="stack" style="gap:10px;">
+            <div class="inline-chips">
+              <span class="badge">ID ${idx}</span>
+              <span class="badge">${formatRelativeHours(idx)}に更新</span>
+            </div>
+            <h3 style="margin:0; font-size:18px;">${article.title || "無題の記事"}</h3>
+            <p class="muted" style="margin:0;">${article.body || "本文がありません"}</p>
+            <div class="tag-row">${(article.tags || []).map(tag => `<a class="tag" href="/tag.html?tag=${encodeURIComponent(tag)}">#${tag}</a>`).join("") || '<span class="tag">#untagged</span>'}</div>
+            <div class="actions" style="justify-content:flex-end;">
+              <a class="share" href="/blog-article.html?id=${idx}" target="_blank">記事を開く</a>
+            </div>
+          </div>
+        `;
+        latestList.appendChild(card);
+      });
+      Lightbox.enhanceImages(latestList);
+    }
+
+    function renderLinks() {
+      const links = BlogData.loadPageLinks();
+      pageLinks.innerHTML = "";
+      if (!links.length) {
+        pageLinks.innerHTML = '<p class="muted">リンクが設定されていません。</p>';
+        return;
+      }
+      links.forEach((link) => {
+        const card = document.createElement("article");
+        card.className = "card";
+        card.innerHTML = `
+          <div class="inline-chips">
+            <span class="badge">${link.id}</span>
+            <span class="badge">${link.url}</span>
+          </div>
+          <h3>${link.title}</h3>
+          <p class="muted">${link.description || ""}</p>
+          <div class="actions" style="justify-content:flex-end;">
+            <a class="share" href="${link.url}">開く</a>
+          </div>
+        `;
+        pageLinks.appendChild(card);
+      });
+    }
+
+    document.addEventListener("DOMContentLoaded", () => {
+      enforceAdminLinks();
+      const articles = BlogData.loadArticles();
+      renderHero(articles);
+      const featuredIds = renderFeatured(articles);
+      renderLatest(articles, featuredIds);
+      renderLinks();
+    });
+  </script>
+
   <script>
     window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
   </script>


### PR DESCRIPTION
## Summary
- add a homepage hero and horizontal featured slider powered by managed articles and links
- add JSON backup/export tooling in the admin editor so articles persist across updates
- harden shared data helpers and styling to support the new top-level layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947c013efc48321a3323a65899fda82)