### PR TITLE
Add header version and updated date display

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="/assets/base.css">
 <body>
   <header class="site-header">
-    <div class="brand">
-      <div class="logo">E</div>
-      <div>
-        <h1>Emperor News Admin</h1>
-        <p>管理者ログインと管理UI</p>
+    <div class="header-leading">
+      <div class="brand">
+        <div class="logo">E</div>
+        <div>
+          <h1>Emperor News Admin</h1>
+          <p>管理者ログインと管理UI</p>
+        </div>
+      </div>
+      <div class="header-meta">
+        <span class="version-pill" data-site-version>v1.0.0</span>
+        <span class="tiny" data-site-updated>最終更新 0000/00/00</span>
       </div>
     </div>
     <div class="actions">
@@ -61,7 +67,7 @@
       </div>
     </section>
   </main>
-
+<script src="/assets/site-meta.js"></script>
 <script src="/assets/lightbox.js"></script>
 <script>
   const SESSION_KEY = "emperor_admin_token";

--- a/public/archive-month.html
+++ b/public/archive-month.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="/assets/blog-shared.css">
 <body>
   <header class="site-header">
-    <div class="brand">
-      <div class="logo">E</div>
-      <div>
-        <h1>月別アーカイブ</h1>
-        <p>タグページから遷移できる月別まとめ</p>
+    <div class="header-leading">
+      <div class="brand">
+        <div class="logo">E</div>
+        <div>
+          <h1>月別アーカイブ</h1>
+          <p>タグページから遷移できる月別まとめ</p>
+        </div>
+      </div>
+      <div class="header-meta">
+        <span class="version-pill" data-site-version>v1.0.0</span>
+        <span class="tiny" data-site-updated>最終更新 0000/00/00</span>
       </div>
     </div>
     <div class="actions">
@@ -29,6 +35,7 @@
     </section>
   </main>
 
+  <script src="/assets/site-meta.js"></script>
   <script>
     const monthList = document.getElementById("monthList");
     const now = new Date();

--- a/public/archive-year.html
+++ b/public/archive-year.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="/assets/blog-shared.css">
 <body>
   <header class="site-header">
-    <div class="brand">
-      <div class="logo">E</div>
-      <div>
-        <h1>年別アーカイブ</h1>
-        <p>タグページの下からアクセスする年別まとめ</p>
+    <div class="header-leading">
+      <div class="brand">
+        <div class="logo">E</div>
+        <div>
+          <h1>年別アーカイブ</h1>
+          <p>タグページの下からアクセスする年別まとめ</p>
+        </div>
+      </div>
+      <div class="header-meta">
+        <span class="version-pill" data-site-version>v1.0.0</span>
+        <span class="tiny" data-site-updated>最終更新 0000/00/00</span>
       </div>
     </div>
     <div class="actions">
@@ -29,6 +35,7 @@
     </section>
   </main>
 
+  <script src="/assets/site-meta.js"></script>
   <script>
     const yearList = document.getElementById("yearList");
     const now = new Date();

--- a/public/assets/base.css
+++ b/public/assets/base.css
@@ -50,6 +50,13 @@ header.site-header {
   border-bottom: 1px solid var(--border);
 }
 
+.header-leading {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
 .brand {
   display: flex;
   align-items: center;
@@ -79,6 +86,24 @@ header.site-header {
   margin: 2px 0 0;
   color: var(--muted);
   font-size: 13px;
+}
+
+.header-meta {
+  display: grid;
+  gap: 6px;
+  align-content: flex-start;
+}
+
+.header-meta .version-pill {
+  background: linear-gradient(135deg, var(--accent), #0ea34f);
+  color: #041902;
+  border: 1px solid #0f2f14;
+  padding: 8px 12px;
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 13px;
+  width: fit-content;
+  box-shadow: 0 8px 24px rgba(6, 199, 85, 0.28);
 }
 
 .actions {
@@ -562,6 +587,7 @@ footer {
 
 @media (max-width: 719px) {
   header.site-header { flex-direction: column; align-items: flex-start; }
+  .header-leading, .actions { width: 100%; }
   .container { padding: 16px 14px 54px; }
   .section-title { flex-direction: column; align-items: flex-start; }
 }

--- a/public/assets/site-meta.js
+++ b/public/assets/site-meta.js
@@ -1,0 +1,19 @@
+(() => {
+  const version = "v1.0.0";
+  const formatDate = new Intl.DateTimeFormat("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+
+  const updated = new Date(document.lastModified || Date.now());
+  const formatted = formatDate.format(updated);
+
+  document.querySelectorAll('[data-site-version]').forEach((el) => {
+    el.textContent = version;
+  });
+
+  document.querySelectorAll('[data-site-updated]').forEach((el) => {
+    el.textContent = `最終更新 ${formatted}`;
+  });
+})();

--- a/public/blog-edit.html
+++ b/public/blog-edit.html
@@ -17,11 +17,17 @@
   </script>
 
   <header class="site-header">
-    <div class="brand">
-      <div class="logo">E</div>
-      <div>
-        <h1>記事編集</h1>
-        <p>公開ビューとは別の管理用編集ページ</p>
+    <div class="header-leading">
+      <div class="brand">
+        <div class="logo">E</div>
+        <div>
+          <h1>記事編集</h1>
+          <p>公開ビューとは別の管理用編集ページ</p>
+        </div>
+      </div>
+      <div class="header-meta">
+        <span class="version-pill" data-site-version>v1.0.0</span>
+        <span class="tiny" data-site-updated>最終更新 0000/00/00</span>
       </div>
     </div>
     <div class="actions">
@@ -252,6 +258,7 @@
     </section>
   </main>
 
+<script src="/assets/site-meta.js"></script>
 <script src="/assets/lightbox.js"></script>
 <script src="/assets/blog-data.js"></script>
 <script>

--- a/public/blog-list.html
+++ b/public/blog-list.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="/assets/blog-shared.css">
 <body>
   <header class="site-header">
-    <div class="brand">
-      <div class="logo">E</div>
-      <div>
-        <h1>Emperor News</h1>
-        <p>一覧ビュー / スマホ・タブレット・PC対応</p>
+    <div class="header-leading">
+      <div class="brand">
+        <div class="logo">E</div>
+        <div>
+          <h1>Emperor News</h1>
+          <p>一覧ビュー / スマホ・タブレット・PC対応</p>
+        </div>
+      </div>
+      <div class="header-meta">
+        <span class="version-pill" data-site-version>v1.0.0</span>
+        <span class="tiny" data-site-updated>最終更新 0000/00/00</span>
       </div>
     </div>
     <div class="actions">
@@ -72,6 +78,7 @@
     </section>
   </main>
 
+  <script src="/assets/site-meta.js"></script>
   <script src="/assets/lightbox.js"></script>
   <script src="/assets/blog-data.js"></script>
   <script>

--- a/public/index.html
+++ b/public/index.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="/assets/base.css">
 <body>
   <header class="site-header">
-    <div class="brand">
-      <div class="logo">E</div>
-      <div>
-        <h1>Emperor News</h1>
-        <p>トップページ / ハイライト &amp; 横スライド特集</p>
+    <div class="header-leading">
+      <div class="brand">
+        <div class="logo">E</div>
+        <div>
+          <h1>Emperor News</h1>
+          <p>トップページ / ハイライト &amp; 横スライド特集</p>
+        </div>
+      </div>
+      <div class="header-meta">
+        <span class="version-pill" data-site-version>v1.0.0</span>
+        <span class="tiny" data-site-updated>最終更新 0000/00/00</span>
       </div>
     </div>
     <div class="actions">
@@ -71,6 +77,7 @@
     </div>
   </footer>
 
+  <script src="/assets/site-meta.js"></script>
   <script src="/assets/lightbox.js"></script>
   <script src="/assets/blog-data.js"></script>
   <script>

--- a/public/tag.html
+++ b/public/tag.html
@@ -6,11 +6,17 @@
 <link rel="stylesheet" href="/assets/blog-shared.css">
 <body>
   <header class="site-header">
-    <div class="brand">
-      <div class="logo">E</div>
-      <div>
-        <h1>タグまとめ</h1>
-        <p>タップしたタグの記事を絞り込み</p>
+    <div class="header-leading">
+      <div class="brand">
+        <div class="logo">E</div>
+        <div>
+          <h1>タグまとめ</h1>
+          <p>タップしたタグの記事を絞り込み</p>
+        </div>
+      </div>
+      <div class="header-meta">
+        <span class="version-pill" data-site-version>v1.0.0</span>
+        <span class="tiny" data-site-updated>最終更新 0000/00/00</span>
       </div>
     </div>
     <div class="actions">
@@ -42,6 +48,7 @@
     </section>
   </main>
 
+  <script src="/assets/site-meta.js"></script>
   <script src="/assets/lightbox.js"></script>
   <script src="/assets/blog-data.js"></script>
   <script>


### PR DESCRIPTION
## Summary
- add version and last-updated info to site headers across public pages
- style the new header metadata badges and grid layout
- add a shared script to populate version text and format the last modified date

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694802ec33a08321838fdffcfe8d8ac3)