### PR TITLE
Add adjustable card height and shared feature slider

### DIFF
--- a/public/assets/base.css
+++ b/public/assets/base.css
@@ -12,6 +12,7 @@
   --radius-lg: 22px;
   --radius: 14px;
   --radius-sm: 10px;
+  --card-height: 380px;
   --page-inline: clamp(16px, 4vw, 32px);
   --page-max: 1200px;
   --tablet: 720px;
@@ -251,7 +252,7 @@ header.site-header {
   border-radius: var(--radius);
   box-shadow: var(--shadow);
   scroll-snap-align: start;
-  min-height: 220px;
+  min-height: var(--card-height);
   overflow: hidden;
 }
 
@@ -272,18 +273,18 @@ header.site-header {
 .featured-card h3 { margin: 0; font-size: 18px; letter-spacing: 0.01em; }
 .featured-card p { margin: 0; color: var(--muted); line-height: 1.6; }
 
-.feature-card {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 12px;
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  background: linear-gradient(145deg, rgba(255,255,255,0.02), rgba(0,0,0,0.4));
-  box-shadow: 0 12px 32px rgba(0,0,0,0.32);
-  scroll-snap-align: start;
-  min-height: 100%;
-}
+  .feature-card {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 12px;
+    border-radius: var(--radius);
+    border: 1px solid var(--border);
+    background: linear-gradient(145deg, rgba(255,255,255,0.02), rgba(0,0,0,0.4));
+    box-shadow: 0 12px 32px rgba(0,0,0,0.32);
+    scroll-snap-align: start;
+    min-height: var(--card-height);
+  }
 
 .feature-thumb {
   width: 100%;
@@ -471,6 +472,7 @@ textarea { resize: vertical; min-height: 140px; }
     display: flex;
     flex-direction: column;
     height: 100%;
+    min-height: var(--card-height);
     border: 1px solid var(--border);
     border-radius: var(--radius);
     background: linear-gradient(145deg, rgba(255,255,255,0.02), rgba(0,0,0,0.35));

--- a/public/assets/blog-data.js
+++ b/public/assets/blog-data.js
@@ -100,8 +100,11 @@
       ? [...new Set(raw.footerIds.filter((idx) => Number.isInteger(idx) && idx >= 0 && idx < limit))]
       : [];
     const homeLatestIds = buildSelection(raw?.homeLatestIds, 4);
-    const homeFeaturedIds = buildSelection(raw?.homeFeaturedIds, 4);
-    return { heroId, featuredId, footerIds, homeLatestIds, homeFeaturedIds };
+    const homeFeaturedIds = buildSelection(raw?.homeFeaturedIds ?? raw?.featureSliderIds, 6);
+    const cardHeight = Number.isInteger(raw?.cardHeight)
+      ? Math.min(800, Math.max(240, raw.cardHeight))
+      : 380;
+    return { heroId, featuredId, footerIds, homeLatestIds, homeFeaturedIds, cardHeight };
   }
 
   function loadSettings() {

--- a/public/blog-edit.html
+++ b/public/blog-edit.html
@@ -65,14 +65,19 @@
           <select id="featuredSelect"></select>
         </div>
         <div class="form-row">
-          <label class="tiny" for="homeFeaturedSelect">トップページの注目記事（横スクロール枠 / 最大4件）</label>
-          <select id="homeFeaturedSelect" multiple size="5"></select>
-          <p class="tiny muted">Cmd/Ctrl + クリックで複数選択できます。最大4件まで優先表示します。</p>
+          <label class="tiny" for="homeFeaturedSelect">特集スライド（トップ/一覧 横スクロール / 最大6件）</label>
+          <select id="homeFeaturedSelect" multiple size="6"></select>
+          <p class="tiny muted">Cmd/Ctrl + クリックで複数選択できます。最大6件まで優先表示し、両ページの特集スライドに反映します。</p>
         </div>
         <div class="form-row">
           <label class="tiny" for="homeLatestSelect">トップページの最新記事（リスト表示 / 最大4件）</label>
           <select id="homeLatestSelect" multiple size="5"></select>
           <p class="tiny muted">選択されたID順で表示します（未選択の場合は先頭から4件）。</p>
+        </div>
+        <div class="form-row">
+          <label class="tiny" for="cardHeight">カードの縦サイズ (px)</label>
+          <input id="cardHeight" name="cardHeight" type="number" min="240" max="800" step="10" placeholder="例: 380">
+          <p class="tiny muted">トップ/一覧の特集・カードレイアウトの高さを調整します。240〜800pxの範囲で設定してください。</p>
         </div>
         <div class="form-row">
           <label class="tiny">固定記事（一覧の最下部に並べます）</label>
@@ -278,6 +283,7 @@
   const featuredSelect = document.getElementById("featuredSelect");
   const homeFeaturedSelect = document.getElementById("homeFeaturedSelect");
   const homeLatestSelect = document.getElementById("homeLatestSelect");
+  const cardHeightInput = document.getElementById("cardHeight");
   const pinnedChoices = document.getElementById("pinnedChoices");
   const settingsStatus = document.getElementById("settingsStatus");
   const copyForm = document.getElementById("copyForm");
@@ -388,6 +394,7 @@
   function renderSettingsForm() {
     const articles = BlogData.loadArticles();
     const settings = BlogData.saveSettings(BlogData.loadSettings());
+    cardHeightInput.value = settings.cardHeight ?? "";
     heroSelect.innerHTML = "";
     featuredSelect.innerHTML = "";
     homeFeaturedSelect.innerHTML = "";
@@ -464,7 +471,7 @@
       pinnedChoices.appendChild(row);
     });
 
-    settingsStatus.textContent = `ヒーロー: ${Number.isInteger(settings.heroId) ? `ID ${settings.heroId}` : "未指定"} / 注目: ${Number.isInteger(settings.featuredId) ? `ID ${settings.featuredId}` : "未指定"} / トップ注目 ${settings.homeFeaturedIds.length} 件 / トップ最新 ${settings.homeLatestIds.length} 件 / 固定 ${settings.footerIds.length} 件`;
+    settingsStatus.textContent = `ヒーロー: ${Number.isInteger(settings.heroId) ? `ID ${settings.heroId}` : "未指定"} / 注目: ${Number.isInteger(settings.featuredId) ? `ID ${settings.featuredId}` : "未指定"} / トップ注目 ${settings.homeFeaturedIds.length} 件 / トップ最新 ${settings.homeLatestIds.length} 件 / 固定 ${settings.footerIds.length} 件 / 高さ ${settings.cardHeight}px`;
   }
 
   function renderCopyForm() {
@@ -835,6 +842,7 @@
     event.preventDefault();
     const heroId = heroSelect.value === "" ? null : parseInt(heroSelect.value, 10);
     const featuredId = featuredSelect.value === "" ? null : parseInt(featuredSelect.value, 10);
+    const cardHeightValue = parseInt(cardHeightInput.value, 10);
     const footerIds = Array.from(pinnedChoices.querySelectorAll('input[type="checkbox"]:checked'))
       .map((input) => parseInt(input.value, 10))
       .filter(Number.isInteger);
@@ -844,8 +852,8 @@
     const homeLatestIds = Array.from(homeLatestSelect.selectedOptions)
       .map((opt) => parseInt(opt.value, 10))
       .filter(Number.isInteger);
-    const normalized = BlogData.saveSettings({ heroId, featuredId, footerIds, homeFeaturedIds, homeLatestIds });
-    settingsStatus.textContent = `ヒーロー: ${Number.isInteger(normalized.heroId) ? `ID ${normalized.heroId}` : "未指定"} / 注目: ${Number.isInteger(normalized.featuredId) ? `ID ${normalized.featuredId}` : "未指定"} / トップ注目 ${normalized.homeFeaturedIds.length} 件 / トップ最新 ${normalized.homeLatestIds.length} 件 / 固定 ${normalized.footerIds.length} 件 保存しました`;
+    const normalized = BlogData.saveSettings({ heroId, featuredId, footerIds, homeFeaturedIds, homeLatestIds, cardHeight: cardHeightValue });
+    settingsStatus.textContent = `ヒーロー: ${Number.isInteger(normalized.heroId) ? `ID ${normalized.heroId}` : "未指定"} / 注目: ${Number.isInteger(normalized.featuredId) ? `ID ${normalized.featuredId}` : "未指定"} / トップ注目 ${normalized.homeFeaturedIds.length} 件 / トップ最新 ${normalized.homeLatestIds.length} 件 / 固定 ${normalized.footerIds.length} 件 / 高さ ${normalized.cardHeight}px 保存しました`;
   }
 
   function handleCopySave(event) {

--- a/public/blog-list.html
+++ b/public/blog-list.html
@@ -46,6 +46,15 @@
       </div>
     </section>
 
+    <section class="panel stack" id="featureRail" style="display:none;">
+      <div class="section-title">
+        <h3>特集スライド</h3>
+        <span class="tiny">管理ページで選んだ記事を横にスライド</span>
+      </div>
+      <div class="scroll-row feature-row" id="featureTrack"></div>
+      <p class="tiny muted" id="featureNote">記事追加後に特集が表示されます。</p>
+    </section>
+
     <section class="split-layout">
       <div class="list-shell">
         <div class="list-head">
@@ -91,6 +100,9 @@
     const featuredCopy = document.getElementById("featuredCopy");
     const featuredShare = document.getElementById("featuredShare");
     const featuredVisual = document.getElementById("featuredVisual");
+    const featureRail = document.getElementById("featureRail");
+    const featureTrack = document.getElementById("featureTrack");
+    const featureNote = document.getElementById("featureNote");
     const pinnedWrapper = document.getElementById("pinnedWrapper");
     const pinnedList = document.getElementById("pinnedList");
     const copyTexts = BlogData.loadCopy();
@@ -124,6 +136,14 @@
     }
 
     applyCopy();
+
+    function applyCardHeight(settings) {
+      if (Number.isInteger(settings?.cardHeight)) {
+        document.documentElement.style.setProperty("--card-height", `${settings.cardHeight}px`);
+      } else {
+        document.documentElement.style.removeProperty("--card-height");
+      }
+    }
 
     function formatRelative(index) {
       const base = Date.now() - index * 3_600_000 * 3;
@@ -196,6 +216,44 @@
       `;
     }
 
+    function renderFeatureRail(list, settings) {
+      featureTrack.innerHTML = "";
+      const selectedIds = settings.homeFeaturedIds?.length
+        ? settings.homeFeaturedIds
+        : list.map((_, idx) => idx);
+      const picked = selectedIds
+        .map((id) => ({ id, article: list[id] }))
+        .filter((item) => Number.isInteger(item.id) && item.article)
+        .slice(0, 6);
+      if (!picked.length) {
+        featureRail.style.display = "none";
+        return;
+      }
+      featureRail.style.display = "grid";
+      picked.forEach(({ article, id }) => {
+        const card = document.createElement("article");
+        card.className = "feature-card";
+        card.innerHTML = `
+          ${article.image ? `<img class="feature-thumb" src="${article.image}" alt="${article.title}">` : '<div class="thumb fallback" style="aspect-ratio:4/3;">NO IMAGE</div>'}
+          <div class="feature-body">
+            <div class="feature-meta">
+              <span class="badge">ID ${id}</span>
+              <span class="badge">${formatRelative(id)}に更新</span>
+            </div>
+            <h3 style="margin:0; font-size:18px; letter-spacing:0.01em;">${article.title || "無題の記事"}</h3>
+            <p class="muted" style="margin:0;">${article.body || "本文がありません"}</p>
+            <div class="meta">${(article.tags || []).map(tag => `<a class="tag" href="/tag.html?tag=${encodeURIComponent(tag)}">#${tag}</a>`).join("") || '<span class="tag">#untagged</span>'}</div>
+            <div class="actions" style="justify-content:flex-end;">
+              <a class="share" href="/blog-article.html?id=${id}" target="_blank">記事を開く</a>
+            </div>
+          </div>
+        `;
+        featureTrack.appendChild(card);
+      });
+      featureNote.textContent = `${picked.length}件の特集を横スライド表示中です。管理ページで並び順とカード高さを調整できます。`;
+      Lightbox.enhanceImages(featureTrack);
+    }
+
     function renderTags(list) {
       tagCloud.innerHTML = "";
       const counts = new Map();
@@ -261,7 +319,9 @@
       enforceAdminLinks();
       const articles = BlogData.loadArticles();
       const settings = BlogData.loadSettings();
+      applyCardHeight(settings);
       renderFeatured(settings, articles);
+      renderFeatureRail(articles, settings);
       renderList(articles);
       renderTags(articles);
       renderMeta(articles.length);

--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,7 @@
         <span class="tiny">管理ページで選択した記事をスライド表示</span>
       </div>
       <div class="scroll-row feature-row" id="featureRow"></div>
-      <p class="tiny muted" id="featureHint">トップページの特集枠です。管理ページの「トップページの注目記事」から設定できます。</p>
+      <p class="tiny muted" id="featureHint">トップ/一覧共通の横スライド特集です。管理ページの「特集スライド」と「カードの縦サイズ」から調整できます。</p>
     </section>
 
     <section class="panel stack latest-list" id="latestSection">
@@ -116,6 +116,14 @@
       return `${days}日前`;
     }
 
+    function applyCardHeight(settings) {
+      if (Number.isInteger(settings?.cardHeight)) {
+        document.documentElement.style.setProperty("--card-height", `${settings.cardHeight}px`);
+      } else {
+        document.documentElement.style.removeProperty("--card-height");
+      }
+    }
+
     function renderHero(articles) {
       const { article, idx } = BlogData.getHeroArticle();
       const target = article ?? articles[0];
@@ -146,7 +154,7 @@
     function renderFeatured(articles) {
       featureRow.innerHTML = "";
       const { list } = BlogData.getHomeFeaturedArticles();
-      const source = list.length ? list : articles.slice(0, 4).map((article, idx) => ({ article, idx }));
+      const source = list.length ? list : articles.slice(0, 6).map((article, idx) => ({ article, idx }));
       if (!source.length) {
         featureSection.style.display = "none";
         return new Set();
@@ -237,6 +245,8 @@
 
     document.addEventListener("DOMContentLoaded", () => {
       enforceAdminLinks();
+      const settings = BlogData.loadSettings();
+      applyCardHeight(settings);
       const articles = BlogData.loadArticles();
       renderHero(articles);
       const featuredIds = renderFeatured(articles);


### PR DESCRIPTION
## Summary
- add a configurable card height setting to the admin layout settings and normalize it in saved settings
- extend the horizontal feature slider selections to be shared across the home and list pages with higher limits
- render the slider on the list page and apply the configurable height to feature and list cards

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69481070f68c8321b59a81f2696f44ca)