### PR TITLE
Adjust type toggle buttons to two-row layout

### DIFF
--- a/Calcu.html
+++ b/Calcu.html
@@ -151,8 +151,19 @@
     }
     .diff{font-size:11px;color:#6b7280;margin-top:2px;}
 
-    .type-toggle{display:flex;flex-direction:column;gap:4px;align-items:center;}
-    .typeBtn{width:92px;white-space:normal;line-height:1.15;}
+    .type-toggle{
+      display:grid;
+      grid-template-columns:repeat(2,minmax(0,1fr));
+      gap:6px;
+      align-items:stretch;
+      justify-items:stretch;
+    }
+    .typeBtn{
+      width:100%;
+      white-space:normal;
+      line-height:1.15;
+    }
+    .typeBtn:nth-child(3){grid-column:1 / -1;}
     .typeBtn.active{background:var(--accent);border-color:var(--accent);color:#fff;}
 
     .vac-btn{

--- a/Calcu/index.html
+++ b/Calcu/index.html
@@ -151,8 +151,19 @@
     }
     .diff{font-size:11px;color:#6b7280;margin-top:2px;}
 
-    .type-toggle{display:flex;flex-direction:column;gap:4px;align-items:center;}
-    .typeBtn{width:92px;white-space:normal;line-height:1.15;}
+    .type-toggle{
+      display:grid;
+      grid-template-columns:repeat(2,minmax(0,1fr));
+      gap:6px;
+      align-items:stretch;
+      justify-items:stretch;
+    }
+    .typeBtn{
+      width:100%;
+      white-space:normal;
+      line-height:1.15;
+    }
+    .typeBtn:nth-child(3){grid-column:1 / -1;}
     .typeBtn.active{background:var(--accent);border-color:var(--accent);color:#fff;}
 
     .vac-btn{


### PR DESCRIPTION
## Summary
- update the type selection buttons to use a two-row grid layout for better spacing
- apply the same layout change to both Calcu entry points

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b756da5148321b46b0572c0764469)