### PR TITLE
Add login session recovery and update calculator layout

### DIFF
--- a/Calcu.html
+++ b/Calcu.html
@@ -39,6 +39,18 @@
     }
     header h1{margin:0;font-size:20px;font-weight:700;}
     header p{margin:2px 0 0;font-size:12px;opacity:.9;}
+    .session-box{
+      display:flex;flex-wrap:wrap;gap:6px;align-items:center;margin-top:6px;
+    }
+    .session-pill{
+      padding:4px 10px;border-radius:999px;
+      background:rgba(255,255,255,.15);color:#fff;
+      font-size:11px;font-weight:800;letter-spacing:0.01em;
+      border:1px solid rgba(255,255,255,.24);
+    }
+    .session-link{
+      color:#ecfeff;font-size:12px;font-weight:700;text-decoration:underline;
+    }
     .sidebar-toggle{
       margin-left:auto;
       border:none;border-radius:999px;
@@ -151,8 +163,12 @@
     }
     .diff{font-size:11px;color:#6b7280;margin-top:2px;}
 
-    .type-toggle{display:flex;flex-direction:column;gap:4px;align-items:center;}
-    .typeBtn{width:92px;white-space:normal;line-height:1.15;}
+    .type-toggle{
+      display:grid;grid-template-columns:repeat(2, minmax(0,1fr));
+      gap:6px;align-items:stretch;justify-items:stretch;
+    }
+    .typeBtn{width:100%;white-space:normal;line-height:1.15;}
+    .type-toggle .typeBtn:last-child{grid-column:1 / -1;}
     .typeBtn.active{background:var(--accent);border-color:var(--accent);color:#fff;}
 
     .vac-btn{
@@ -182,9 +198,13 @@
       <h1>延長・預り保育 計算</h1>
       <p>延長：30分200円（3,000円上限）／ 預り：定額（要件反映済）</p>
       <p style="font-size:11px;margin:4px 0 0;opacity:0.85;">
-        <span style="font-weight:700;">v1.3.0</span> | 
+        <span style="font-weight:700;">v1.4.0</span> | 
         最終更新: <span id="lastUpdated">--</span>
       </p>
+      <div class="session-box">
+        <span class="session-pill" id="userBadge">未ログイン</span>
+        <a class="session-link" href="login.html">ログイン / 前回の画面に戻る</a>
+      </div>
     </div>
     <button id="toggleSidebar" class="sidebar-toggle">サイドバーをとじる</button>
   </header>
@@ -261,6 +281,7 @@
     </div>
   </main>
 
+<script src="./session-helper.js"></script>
 <script>
 /* =========================
    状態・設定
@@ -939,6 +960,31 @@ function makeRecordKey({rawDate, school, clazz, name}){
 }
 
 /* =========================
+   ログイン連携
+========================= */
+function updateUserBadge(){
+  const badge = document.getElementById("userBadge");
+  if (!badge || !window.PortalSession) return;
+  const user = PortalSession.getCurrentUser();
+  if (user){
+    const info = PortalSession.getUserInfo(user);
+    const lastLabel = info?.lastTitle || info?.lastPath || "";
+    badge.textContent = `ログイン中: ${user}`;
+    badge.title = lastLabel ? `前回: ${lastLabel}` : "前回の画面を記録します";
+  } else {
+    badge.textContent = "未ログイン";
+    badge.title = "ログインして前回の画面を記録します";
+  }
+}
+
+function rememberCurrentPage(){
+  if (!window.PortalSession) return;
+  const path = location.pathname + location.search + location.hash;
+  PortalSession.rememberPage(path, document.title);
+  updateUserBadge();
+}
+
+/* =========================
    永続化
 ========================= */
 function loadState(){
@@ -982,6 +1028,7 @@ function updateLastModified(){
 
 // Initialize on load
 updateLastModified();
+rememberCurrentPage();
 </script>
 </body>
 </html>

--- a/Calcu/index.html
+++ b/Calcu/index.html
@@ -39,6 +39,18 @@
     }
     header h1{margin:0;font-size:20px;font-weight:700;}
     header p{margin:2px 0 0;font-size:12px;opacity:.9;}
+    .session-box{
+      display:flex;flex-wrap:wrap;gap:6px;align-items:center;margin-top:6px;
+    }
+    .session-pill{
+      padding:4px 10px;border-radius:999px;
+      background:rgba(255,255,255,.15);color:#fff;
+      font-size:11px;font-weight:800;letter-spacing:0.01em;
+      border:1px solid rgba(255,255,255,.24);
+    }
+    .session-link{
+      color:#ecfeff;font-size:12px;font-weight:700;text-decoration:underline;
+    }
     .sidebar-toggle{
       margin-left:auto;
       border:none;border-radius:999px;
@@ -151,8 +163,12 @@
     }
     .diff{font-size:11px;color:#6b7280;margin-top:2px;}
 
-    .type-toggle{display:flex;flex-direction:column;gap:4px;align-items:center;}
-    .typeBtn{width:92px;white-space:normal;line-height:1.15;}
+    .type-toggle{
+      display:grid;grid-template-columns:repeat(2, minmax(0,1fr));
+      gap:6px;align-items:stretch;justify-items:stretch;
+    }
+    .typeBtn{width:100%;white-space:normal;line-height:1.15;}
+    .type-toggle .typeBtn:last-child{grid-column:1 / -1;}
     .typeBtn.active{background:var(--accent);border-color:var(--accent);color:#fff;}
 
     .vac-btn{
@@ -182,9 +198,13 @@
       <h1>延長・預り保育 計算</h1>
       <p>延長：30分200円（3,000円上限）／ 預り：定額（要件反映済）</p>
       <p style="font-size:11px;margin:4px 0 0;opacity:0.85;">
-        <span style="font-weight:700;">v1.3.0</span> | 
+        <span style="font-weight:700;">v1.4.0</span> | 
         最終更新: <span id="lastUpdated">--</span>
       </p>
+      <div class="session-box">
+        <span class="session-pill" id="userBadge">未ログイン</span>
+        <a class="session-link" href="../login.html">ログイン / 前回の画面に戻る</a>
+      </div>
     </div>
     <button id="toggleSidebar" class="sidebar-toggle">サイドバーをとじる</button>
   </header>
@@ -261,6 +281,7 @@
     </div>
   </main>
 
+<script src="../session-helper.js"></script>
 <script>
 /* =========================
    状態・設定
@@ -939,6 +960,31 @@ function makeRecordKey({rawDate, school, clazz, name}){
 }
 
 /* =========================
+   ログイン連携
+========================= */
+function updateUserBadge(){
+  const badge = document.getElementById("userBadge");
+  if (!badge || !window.PortalSession) return;
+  const user = PortalSession.getCurrentUser();
+  if (user){
+    const info = PortalSession.getUserInfo(user);
+    const lastLabel = info?.lastTitle || info?.lastPath || "";
+    badge.textContent = `ログイン中: ${user}`;
+    badge.title = lastLabel ? `前回: ${lastLabel}` : "前回の画面を記録します";
+  } else {
+    badge.textContent = "未ログイン";
+    badge.title = "ログインして前回の画面を記録します";
+  }
+}
+
+function rememberCurrentPage(){
+  if (!window.PortalSession) return;
+  const path = location.pathname + location.search + location.hash;
+  PortalSession.rememberPage(path, document.title);
+  updateUserBadge();
+}
+
+/* =========================
    永続化
 ========================= */
 function loadState(){
@@ -982,6 +1028,7 @@ function updateLastModified(){
 
 // Initialize on load
 updateLastModified();
+rememberCurrentPage();
 </script>
 </body>
 </html>

--- a/Chat/Index.html
+++ b/Chat/Index.html
@@ -62,6 +62,12 @@
       background: radial-gradient(circle at top left, rgba(56,189,248,0.1), transparent 60%);
     }
 
+    .title-block {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
     header .title {
       font-size: 18px;
       font-weight: 600;
@@ -85,6 +91,39 @@
     header .subtitle {
       font-size: 12px;
       color: var(--text-muted);
+    }
+
+    .session-box {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+
+    .header-right {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+
+    .login-pill {
+      padding: 6px 10px;
+      border-radius: 999px;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      background: rgba(15,23,42,0.7);
+      font-size: 11px;
+      color: var(--text-main);
+      font-weight: 700;
+    }
+
+    .login-link {
+      color: var(--text-muted);
+      font-size: 12px;
+      text-decoration: underline;
+      font-weight: 700;
     }
 
     /* --- PC View (default) --- */
@@ -679,15 +718,21 @@
 <body>
   <div class="app-shell">
     <header>
-      <div>
+      <div class="title-block">
         <div class="title">
           <span class="logo">TOC</span>
           <span>Chat TOC Maker</span>
         </div>
         <div class="subtitle">会話ログから自動でカテゴリ別の「目次」を作成してジャンプ ✨</div>
       </div>
-      <div class="badge">
-        🔨🤖🔧 <span>HTML + CSS + JS だけでローカル動作</span>
+      <div class="header-right">
+        <div class="badge">
+          🔨🤖🔧 <span>HTML + CSS + JS だけでローカル動作</span>
+        </div>
+        <div class="session-box">
+          <span class="login-pill" id="chatUserBadge">未ログイン</span>
+          <a class="login-link" href="../login.html">ログイン / 前回の画面へ</a>
+        </div>
       </div>
     </header>
 
@@ -1171,9 +1216,29 @@ Assistant: 小さな「完成するもの」を作るのがおすすめです。
     });
   </script>
 
-<script>
-  window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
-</script>
-<script defer src="/_vercel/insights/script.js"></script>
+  <script src="../session-helper.js"></script>
+  <script>
+    (function(){
+      if(!window.PortalSession) return;
+      const badge = document.getElementById("chatUserBadge");
+      const path = location.pathname + location.search + location.hash;
+      PortalSession.rememberPage(path, document.title);
+      if(!badge) return;
+      const user = PortalSession.getCurrentUser();
+      if (user){
+        const info = PortalSession.getUserInfo(user);
+        badge.textContent = `ログイン中: ${user}`;
+        badge.title = info?.lastTitle || info?.lastPath || "";
+      } else {
+        badge.textContent = "未ログイン";
+        badge.title = "ログインすると前回の画面を記録します";
+      }
+    })();
+  </script>
+
+  <script>
+    window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
+  </script>
+  <script defer src="/_vercel/insights/script.js"></script>
 </body>
 </html>

--- a/Index.html
+++ b/Index.html
@@ -287,6 +287,22 @@
         </ul>
         <div class="btn">ツールを開く →</div>
       </a>
+
+      <a href="login.html" class="card">
+        <div class="card-title">
+          <div class="card-icon">🔑</div>
+          ログイン & 画面復元
+        </div>
+        <p class="card-description">ユーザーごとに最後に見た画面へ自動ジャンプ</p>
+        <ul class="card-features">
+          <li>ユーザー名だけで簡易ログイン</li>
+          <li>前回の画面を保存して自動復元</li>
+          <li>複数ユーザーの履歴を保持</li>
+          <li>ローカル保存のみで安心</li>
+          <li>トップへ戻るリンク付き</li>
+        </ul>
+        <div class="btn">ログインページを開く →</div>
+      </a>
     </div>
 
     <div class="info-panel">
@@ -308,5 +324,12 @@
       <p>© 2024 保育園延長・預かり保育計算ツール</p>
     </footer>
   </div>
+  <script src="session-helper.js"></script>
+  <script>
+    if (window.PortalSession) {
+      const path = location.pathname + location.search + location.hash;
+      PortalSession.rememberPage(path, document.title);
+    }
+  </script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ログイン | 前回の画面を復元</title>
+  <style>
+    :root{
+      --accent:#06b6d4;
+      --accent-2:#0891b2;
+      --bg:#0b1621;
+      --panel:#0f1f2f;
+      --border:#163042;
+      --text:#e5edf5;
+      --muted:#9fb6c8;
+    }
+    *{box-sizing:border-box;}
+    html,body{margin:0;padding:0;}
+    body{
+      font-family:"Noto Sans JP",system-ui,-apple-system,"Segoe UI",sans-serif;
+      background:radial-gradient(circle at 20% 20%, rgba(6,182,212,.25), transparent 32%),
+        radial-gradient(circle at 80% 0%, rgba(8,145,178,.18), transparent 32%),
+        var(--bg);
+      color:var(--text);
+      min-height:100vh;
+      padding:24px;
+      display:flex;align-items:center;justify-content:center;
+    }
+    .container{width:100%;max-width:960px;display:grid;gap:16px;}
+    .panel{
+      background:var(--panel);
+      border:1px solid var(--border);
+      border-radius:14px;
+      padding:18px;
+      box-shadow:0 16px 50px rgba(0,0,0,.28);
+    }
+    header{
+      display:flex;align-items:center;justify-content:space-between;
+      gap:12px;
+    }
+    .brand{
+      display:flex;align-items:center;gap:10px;
+    }
+    .logo{
+      width:42px;height:42px;border-radius:12px;
+      background:linear-gradient(145deg, #e0f2fe, #cffafe);
+      color:#0e7490;font-weight:900;font-size:20px;
+      display:flex;align-items:center;justify-content:center;
+      box-shadow:0 10px 24px rgba(0,0,0,.3);
+    }
+    h1{margin:0;font-size:22px;letter-spacing:0.01em;}
+    .subtitle{margin:0;color:var(--muted);font-size:13px;}
+    .link-btn{
+      color:var(--text);text-decoration:none;font-weight:800;
+      border:1px solid var(--border);padding:8px 12px;border-radius:999px;
+      background:rgba(255,255,255,.04);
+    }
+    form{display:grid;gap:10px;}
+    label{font-weight:800;font-size:13px;}
+    input[type="text"]{
+      width:100%;padding:12px 14px;border-radius:10px;border:1px solid var(--border);
+      background:rgba(255,255,255,.04);color:var(--text);font-size:15px;
+    }
+    input:focus{outline:none;border-color:var(--accent);box-shadow:0 0 0 3px rgba(6,182,212,.18);}
+    button{
+      border:none;border-radius:10px;padding:12px 14px;
+      background:linear-gradient(120deg, var(--accent), var(--accent-2));
+      color:#fff;font-weight:800;cursor:pointer;font-size:14px;
+      box-shadow:0 8px 24px rgba(6,182,212,.25);
+    }
+    .ghost{
+      background:rgba(255,255,255,.04);
+      border:1px solid var(--border);
+      color:var(--text);
+      box-shadow:none;
+    }
+    .muted{color:var(--muted);font-size:13px;}
+    .status{
+      background:rgba(255,255,255,.04);
+      border:1px dashed var(--border);
+      border-radius:12px;
+      padding:10px 12px;
+      font-size:13px;
+    }
+    .user-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:10px;}
+    .user-card{
+      border:1px solid var(--border);
+      border-radius:12px;
+      padding:12px;
+      background:rgba(255,255,255,.02);
+      display:grid;gap:6px;
+    }
+    .user-title{font-weight:900;font-size:15px;}
+    .pill{
+      display:inline-flex;align-items:center;gap:6px;
+      padding:4px 8px;border-radius:999px;
+      background:rgba(6,182,212,.15);color:#e0faff;font-weight:800;font-size:11px;
+    }
+    .small-actions{display:flex;gap:8px;flex-wrap:wrap;}
+    .hint{font-size:12px;color:var(--muted);}
+    @media(max-width:640px){
+      body{padding:14px;}
+      h1{font-size:19px;}
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header class="panel">
+      <div class="brand">
+        <div class="logo">園</div>
+        <div>
+          <h1>ログインで前回の画面を復元</h1>
+          <p class="subtitle">ユーザーごとに最後に開いたページへ自動ジャンプします</p>
+        </div>
+      </div>
+      <a class="link-btn" href="Index.html">ポータルに戻る</a>
+    </header>
+
+    <section class="panel">
+      <form id="loginForm">
+        <div>
+          <label for="username">ユーザー名</label>
+          <input id="username" name="username" type="text" placeholder="例: tanaka" autocomplete="username" required>
+        </div>
+        <div class="small-actions" style="align-items:center;justify-content:space-between;">
+          <div class="hint">ログインすると前回の画面を保存し、自動で開きます。</div>
+          <button type="submit">ログインして前回の画面を開く</button>
+        </div>
+      </form>
+      <p class="muted" style="margin:6px 0 0;">※ パスワード不要の簡易ログインです。同じ端末のローカル保存のみ使用します。</p>
+    </section>
+
+    <section class="panel">
+      <div style="display:flex;align-items:center;justify-content:space-between;gap:10px;">
+        <h2 style="margin:0;font-size:16px;">最近利用したユーザー</h2>
+        <button type="button" class="ghost" id="logoutBtn">ログアウト</button>
+      </div>
+      <div id="userList" class="user-list" style="margin-top:12px;"></div>
+      <p class="hint" id="userHint" style="margin:10px 0 0;"></p>
+    </section>
+
+    <section class="panel status" id="statusBox">
+      前回の画面を確認しています...
+    </section>
+  </div>
+
+  <script src="session-helper.js"></script>
+  <script>
+    const statusBox = document.getElementById("statusBox");
+    const userList = document.getElementById("userList");
+    const userHint = document.getElementById("userHint");
+    const loginForm = document.getElementById("loginForm");
+    const usernameInput = document.getElementById("username");
+    const logoutBtn = document.getElementById("logoutBtn");
+    let redirectTimer = null;
+
+    function sanitizeTarget(path){
+      if(!path) return "Index.html";
+      const normalized = path.split("#")[0].split("?")[0];
+      if(/login\.html$/i.test(normalized)) return "Index.html";
+      return path;
+    }
+
+    function renderUsers(){
+      if(!window.PortalSession){
+        userList.innerHTML = "<p class='muted'>セッション情報を読み込めませんでした。</p>";
+        return;
+      }
+      const users = PortalSession.getAllUsers();
+      if(!users.length){
+        userList.innerHTML = "<p class='muted'>まだ保存済みのユーザーはいません。</p>";
+        userHint.textContent = "ユーザー名でログインすると、ここに最近利用した人が表示されます。";
+        return;
+      }
+      userHint.textContent = "カードをクリックすると、そのユーザーでログインし前回の画面を開きます。";
+      userList.innerHTML = users.map(u=>{
+        const label = u.lastTitle || u.lastPath || "最後に開いた画面なし";
+        const when = u.lastVisitedAt ? new Date(u.lastVisitedAt).toLocaleString("ja-JP") : "-";
+        return `
+          <button type="button" class="user-card" data-user="${u.name}">
+            <div class="user-title">${u.name}</div>
+            <div class="pill">前回: ${label}</div>
+            <div class="hint">最終利用: ${when}</div>
+          </button>
+        `;
+      }).join("");
+      userList.querySelectorAll("[data-user]").forEach(btn=>{
+        btn.addEventListener("click", ()=> handleLogin(btn.dataset.user));
+      });
+    }
+
+    function startRedirect(target, label){
+      clearTimeout(redirectTimer);
+      const safeTarget = sanitizeTarget(target);
+      const displayLabel = label || safeTarget;
+      statusBox.textContent = `${displayLabel} を開いています...`;
+      redirectTimer = setTimeout(()=>{ location.href = safeTarget; }, 700);
+    }
+
+    function handleLogin(name){
+      if(!name || !window.PortalSession) return;
+      const user = PortalSession.setCurrentUser(name);
+      const info = PortalSession.getUserInfo(user);
+      const target = sanitizeTarget(info?.lastPath);
+      const label = info?.lastTitle || target || "トップページ";
+      statusBox.textContent = info?.lastPath
+        ? `前回の画面 (${label}) に移動します。`
+        : "前回の画面が未保存のためトップページを開きます。";
+      startRedirect(target, label);
+      renderUsers();
+    }
+
+    loginForm.addEventListener("submit", (e)=>{
+      e.preventDefault();
+      handleLogin(usernameInput.value.trim());
+    });
+
+    logoutBtn.addEventListener("click", ()=>{
+      if(!window.PortalSession) return;
+      PortalSession.clearCurrentUser();
+      statusBox.textContent = "ログアウトしました。ユーザー名を入力して再ログインしてください。";
+      clearTimeout(redirectTimer);
+      renderUsers();
+    });
+
+    document.addEventListener("DOMContentLoaded", ()=>{
+      renderUsers();
+      if(!window.PortalSession){
+        statusBox.textContent = "セッション管理が利用できません。";
+        return;
+      }
+      const current = PortalSession.getCurrentUser();
+      if(current){
+        const info = PortalSession.getUserInfo(current);
+        if(info?.lastPath){
+          statusBox.textContent = `ログイン中: ${current} / 前回: ${info.lastTitle || info.lastPath} を開きます。`;
+          startRedirect(info.lastPath, info.lastTitle || info.lastPath);
+        }else{
+          statusBox.textContent = `ログイン中: ${current} / 前回の画面は未保存です。`;
+        }
+      }else{
+        statusBox.textContent = "ユーザー名を入力すると、前回の画面を自動で開きます。";
+      }
+    });
+  </script>
+</body>
+</html>

--- a/session-helper.js
+++ b/session-helper.js
@@ -1,0 +1,91 @@
+(function () {
+  const STORAGE_KEY = "portal_user_sessions_v1";
+  const FALLBACK = { currentUser: null, users: {} };
+
+  function safeParse(raw) {
+    if (!raw) return { ...FALLBACK };
+    try {
+      const parsed = JSON.parse(raw);
+      return {
+        currentUser: parsed.currentUser || null,
+        users: parsed.users || {},
+      };
+    } catch {
+      return { ...FALLBACK };
+    }
+  }
+
+  function loadSession() {
+    return safeParse(localStorage.getItem(STORAGE_KEY));
+  }
+
+  function saveSession(data) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch {
+      /* no-op */
+    }
+  }
+
+  function setCurrentUser(name) {
+    const trimmed = (name || "").trim();
+    if (!trimmed) return null;
+    const data = loadSession();
+    data.currentUser = trimmed;
+    data.users[trimmed] = data.users[trimmed] || {};
+    data.users[trimmed].lastVisitedAt = Date.now();
+    saveSession(data);
+    return trimmed;
+  }
+
+  function clearCurrentUser() {
+    const data = loadSession();
+    data.currentUser = null;
+    saveSession(data);
+  }
+
+  function rememberPage(path, title) {
+    const data = loadSession();
+    if (!data.currentUser) return;
+    const targetPath =
+      path ||
+      (typeof location !== "undefined"
+        ? location.pathname + location.search + location.hash
+        : "/");
+    const entry = data.users[data.currentUser] || {};
+    entry.lastPath = targetPath;
+    entry.lastTitle = title || (typeof document !== "undefined" ? document.title : "");
+    entry.lastVisitedAt = Date.now();
+    data.users[data.currentUser] = entry;
+    saveSession(data);
+  }
+
+  function getCurrentUser() {
+    const data = loadSession();
+    return data.currentUser || null;
+  }
+
+  function getUserInfo(name) {
+    const data = loadSession();
+    const entry = data.users?.[name];
+    if (!entry) return null;
+    return { name, ...entry };
+  }
+
+  function getAllUsers() {
+    const data = loadSession();
+    return Object.entries(data.users || {})
+      .map(([name, info]) => ({ name, ...info }))
+      .sort((a, b) => (b.lastVisitedAt || 0) - (a.lastVisitedAt || 0));
+  }
+
+  window.PortalSession = {
+    load: loadSession,
+    setCurrentUser,
+    clearCurrentUser,
+    rememberPage,
+    getCurrentUser,
+    getUserInfo,
+    getAllUsers,
+  };
+})();


### PR DESCRIPTION
## Summary
- add a reusable session helper and login page that restores each user to their last screen automatically
- track visits from the portal, calculator, and chat pages so the last page is saved per user and surface login links in their headers
- adjust the calculator type selection buttons to a two-row layout and refresh header versioning

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b77644e64832198e89d755736cc0f)